### PR TITLE
Fix to support Fabulous 0.40

### DIFF
--- a/src/FromCompilerService.fs
+++ b/src/FromCompilerService.fs
@@ -240,7 +240,7 @@ type Convert(includeRanges: bool) =
         let paramTypesR = convParamTypes memb
 
         // TODO: extensions of generic type
-        if memb.IsExtensionMember && memb.ApparentEnclosingEntity.GenericParameters.Count > 0 && not (memb.CompiledName = "ProgramRunner`2.EnableLiveUpdate") then 
+        if memb.IsExtensionMember && memb.ApparentEnclosingEntity.GenericParameters.Count > 0 && not (memb.CompiledName = "ProgramRunner`2.EnableLiveUpdate" || memb.CompiledName = "ProgramRunner`3.EnableLiveUpdate") then 
            failwithf "NYI: extension of generic type, needs FCS support: %A::%A" memb.ApparentEnclosingEntity memb
 
         { Entity=convEntityRef memb.DeclaringEntity.Value


### PR DESCRIPTION
Fabulous changed its `Program` from `Program<'model, 'msg>` to `Program<'arg, 'model, 'msg>` to mimick what's available in Elmish (`'view` is fixed inside Fabulous).

This change made LiveUpdate stop working because PortaCode was expecting a ProgramRunner with only 2 type arguments.
See https://github.com/fsprojects/Fabulous/issues/510

This PR adds support for ProgramRunner`3

Seeing the TODO comment, maybe there would be a better way to do this?