### PR TITLE
Dynamically emit shell types

### DIFF
--- a/FsLive.Cli/FsLive.Cli.fsproj
+++ b/FsLive.Cli/FsLive.Cli.fsproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net471;netcoreapp2.1</TargetFrameworks>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <DefineConstants>$(DefineConstants);NETSTANDARD2_0</DefineConstants>
-        <PackAsTool>True</PackAsTool>
-        <ToolCommandName>fslive</ToolCommandName>
+        <IsPackable>true</IsPackable>
+        <PackAsTool>true</PackAsTool>
+        <AssemblyName>fslive</AssemblyName>
         <PackageOutputPath>./nupkg</PackageOutputPath>
-      <PlatformTarget>x64</PlatformTarget>
+        <PlatformTarget>x64</PlatformTarget>
     </PropertyGroup>
     <PropertyGroup>
         <PackageId>fslive-cli</PackageId>

--- a/FsLive.sln
+++ b/FsLive.sln
@@ -1,13 +1,20 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2006
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30413.136
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FsLive.Cli", "FsLive.Cli\FsLive.Cli.fsproj", "{23640E46-E830-4AB7-9289-E527F6429435}"
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FsLive.Cli.Tests", "tests\FsLive.Cli.Tests.fsproj", "{810EEB40-5042-4946-B695-5B13E9957807}"
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.Compiler.PortaCode", "src\FSharp.Compiler.PortaCode.fsproj", "{2E0E56A3-44F1-4953-8CE5-4DBC477DBF05}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{569DC946-97D8-4B47-B229-38A137CD388E}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		LICENSE.md = LICENSE.md
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/README.md
+++ b/README.md
@@ -1,19 +1,37 @@
 # FSharp.Compiler.PortaCode
-The PortaCode F# code format and corresponding interpreter. 
 
-* Used by Fabulous and others.
+An F# code format and corresponding interpreter. 
 
 * Currently distributed by source inclusion or 'fslive' tool, no nuget package yet
 
-* FsLive.Cli is a live programming "watch my project" command line tool which is experimental, e.g. 
+* `dotnet fslive` is a live programming "watch my project" command line tool, e.g. 
 
-       FsLive.Cli\bin\Debug\netcoreapp3.1\fslive.exe foo.fsx
-       
-* Wet paint, API will change
+       dotnet fslive foo.fsx
+       dotnet fslive MyProject.fsproj
 
-It's used for the "LiveUpdate" feature of Fabulous, to interpret the Elmish model/view/update application code on-device.
+* Used by Fabulous, DiffSharp and others.
 
-The interpreter may also be useful for other live checking tools, because you get escape the whole complication of actual IL generation, Reflection emit and reflection invoke, and no actual classes etc are generated. We can also adapt the interpreter over time to do things like report extra information back to the host.
+The overall aim of the interpreter is to execute F# code in "unusual" ways, e.g. 
+
+* **Live checking** - Only executing selective slices of code (e.g. `LiveCheck` checks, see below)
+
+* **Observed execution** - Watch execution by collecting information about the values flowing through different variables,
+  for use in hover tips.
+
+* **Symbolic execution** - This is done in cooperation with the target libraries
+  which must allow injection of symbols into the computational structure, e.g. the injection of
+  symbolic shape variables into the shapes of tensors, and the collection and processing of
+  associated constraints on those variables.
+
+* **Execution without Reflection.Emit** - Some platforms don't support Reflection.Emit.  However
+  be aware that execution on such platforms with this intepreter is approximate with many F# language
+  features not supported correctly.
+
+The interpreter is used for the "LiveUpdate" feature of Fabulous, to interpret the Elmish model/view/update application code on-device.
+
+The interpreter may also be useful for other live checking tools, because you get
+escape the whole complication of actual IL generation, Reflection emit and reflection invoke,
+and no actual classes etc are generated.
 
 ### Code format
 
@@ -39,7 +57,7 @@ Arguments:
    --once            Don't enter watch mode (default: watch the source files of the project for changes)
    --send:<url>      Send the JSON-encoded contents of the PortaCode to the webhook
    --send            Equivalent to --send:http://localhost:9867/update
-   --msbuildarg:arg  An MSBuild argument e.g. /p:Configuration=Release
+   --projarg:arg     An MSBuild argument e.g. /p:Configuration=Release
    --dump            Dump the contents to console after each update
    --livecheck       Only evaluate those with a LiveCheck attribute. This uses on-demand execution semantics for top-level declarations
                      Also write an info file based on results of evaluation, and watch for .fsharp/foo.fsx.edit files and use the 
@@ -51,10 +69,16 @@ Arguments:
 
 * A LiveCheck is a declaration like this: https://github.com/fsprojects/TensorFlow.FSharp/blob/master/examples/NeuralStyleTransfer-dsl.fsx#L109 …
 
-* The attribute indicates the intent that that specific piece of code (and anything it depends on) should be run at development time. This is _not_ done by the IDE directly but by some other tool you have to start.
+* The attribute indicates the intent that that specific piece of code (and anything it
+  depends on) should be run at development time.
 
-* An example tool is the "fslive.exe" tool from this repo here https://github.com/fsprojects/FSharp.Compiler.PortaCode/blob/master/src/ProcessCommandLine.fs#L46.  Like FsAutoComplete this watches for project changes and then recompiles using FCS and looks for LiveCheck attributes.  It then interprets those evaluations using reflection and collects information about the execution.  For example, it detects errors and detects when variables have been bound to particular values during interpretation.  The tool currently emits a ".fsharp/file.fsx.info" file containing extra information about the file "file.fsx" - extra error messages and extra tooltips.  An experimenta  FCS modification notices the existence of this file and incorporates the added information into Intellisense results. This keeps the checker tool totally decoupled from the IDE tooling.  
+* An example tool is the "fslive.exe" tool from this repo here https://github.com/fsprojects/FSharp.Compiler.PortaCode/blob/master/src/ProcessCommandLine.fs#L46.
+  Like FsAutoComplete this watches for project changes and then recompiles using FCS and looks for LiveCheck attributes.  It then interprets those evaluations
+  using reflection and collects information about the execution.  For example, it detects errors and detects when variables have been bound to particular values
+  during interpretation.  The tool currently emits a ".fsharp/file.fsx.info" file containing extra information about the file "file.fsx" - extra error messages
+  and extra tooltips.  An experimenta  FCS modification notices the existence of this file and incorporates the added information into Intellisense results. This
+  keeps the checker tool totally decoupled from the IDE tooling.  
 
-* This functionality may be reconfigured to be an [F# Analyzer](https://medium.com/lambda-factory/introducing-f-analyzers-772487889429).  
+* This functionality may one day be reconfigured to be an [F# Analyzer](https://medium.com/lambda-factory/introducing-f-analyzers-772487889429).  
  
 

--- a/README.md
+++ b/README.md
@@ -3,23 +3,21 @@ The PortaCode F# code format and corresponding interpreter.
 
 * Used by Fabulous and others.
 
-* Currently distributed by source inclusion, no nuget package yet
+* Currently distributed by source inclusion or 'fslive' tool, no nuget package yet
 
-* FsLive.Cli is a live programming "watch my project" command line tool which is experimental
+* FsLive.Cli is a live programming "watch my project" command line tool which is experimental, e.g. 
 
+       FsLive.Cli\bin\Debug\netcoreapp3.1\fslive.exe foo.fsx
+       
 * Wet paint, API will change
 
 It's used for the "LiveUpdate" feature of Fabulous, to interpret the Elmish model/view/update application code on-device.
-
-It's also used for the experimental "LiveCheck" feature of
-It's not actually necessary on Android since full mono JIT is available. On iOS it appears necessary.
 
 The interpreter may also be useful for other live checking tools, because you get escape the whole complication of actual IL generation, Reflection emit and reflection invoke, and no actual classes etc are generated. We can also adapt the interpreter over time to do things like report extra information back to the host.
 
 ### Code format
 
 The input code format for the interpreter (PortaCode) is derived from FSharp.Compiler.Service expressions, the code is in this repo.
-
 
 ### Interpretation
 
@@ -29,13 +27,25 @@ Library calls are implemented by reflection invoke.  It's the same interpreter w
 
 ### Command line arguments
 
-    --webhook url      send JSON serialized PortaCode to webhook
-    --eval             evaluate contents using the interpreter
-    --livechecksonly   see below, only evaluate LiveChecks and their dependencies
-    --writeinfo        write info files for IDE tooling (experimental)
-    --vshack           (experimental)
+```
+Usage: <tool> arg .. arg [-- <other-args>]
+       <tool> @args.rsp  [-- <other-args>]
+       <tool> ... Project.fsproj ... [-- <other-args>]
 
-Fabulous uses a `--webhook` argument in combination with `--watch` to send a serialized version of the code to a web request on each change.
+The default source is a single project file in the current directory.
+The default output is a JSON dump of the PortaCode.
+
+Arguments:
+   --once            Don't enter watch mode (default: watch the source files of the project for changes)
+   --send:<url>      Send the JSON-encoded contents of the PortaCode to the webhook
+   --send            Equivalent to --send:http://localhost:9867/update
+   --msbuildarg:arg  An MSBuild argument e.g. /p:Configuration=Release
+   --dump            Dump the contents to console after each update
+   --livecheck       Only evaluate those with a LiveCheck attribute. This uses on-demand execution semantics for top-level declarations
+                     Also write an info file based on results of evaluation, and watch for .fsharp/foo.fsx.edit files and use the 
+                     contents of those in preference to the source file
+   <other-args>      All other args are assumed to be extra F# command line arguments, e.g. --define:FOO
+```   
 
 ### LiveChecks
 
@@ -43,8 +53,8 @@ Fabulous uses a `--webhook` argument in combination with `--watch` to send a ser
 
 * The attribute indicates the intent that that specific piece of code (and anything it depends on) should be run at development time. This is _not_ done by the IDE directly but by some other tool you have to start.
 
-* An example tool is the "fslive.exe" tool (soon to be a global command) from this repo here https://github.com/fsprojects/FSharp.Compiler.PortaCode/blob/master/src/ProcessCommandLine.fs#L46.  Like FsAutoComplete this watches for project changes and then recompiles using FCS and looks for LiveCheck attributes.  It then interprets those evaluations using reflection and collects information about the execution.  For example, it detects errors and detects when variables have been bound to particular values during interpretation.  
+* An example tool is the "fslive.exe" tool from this repo here https://github.com/fsprojects/FSharp.Compiler.PortaCode/blob/master/src/ProcessCommandLine.fs#L46.  Like FsAutoComplete this watches for project changes and then recompiles using FCS and looks for LiveCheck attributes.  It then interprets those evaluations using reflection and collects information about the execution.  For example, it detects errors and detects when variables have been bound to particular values during interpretation.  The tool currently emits a ".fsharp/file.fsx.info" file containing extra information about the file "file.fsx" - extra error messages and extra tooltips.  An experimenta  FCS modification notices the existence of this file and incorporates the added information into Intellisense results. This keeps the checker tool totally decoupled from the IDE tooling.  
 
-* This may be reconfigured to be an [F# Analyzer](https://medium.com/lambda-factory/introducing-f-analyzers-772487889429).  The tool currently emits a ".fsharp/file.fsx.info" file containing extra information about the file "file.fsx" - extra error messages and extra tooltips.  The FCS modification is to notice the existence of this file and incorporate the added information into Intellisense results. It keeps the checker tool totally decoupled from the IDE tooling.  We could use a different protocol later, also it could be extended to include more information.
+* This functionality may be reconfigured to be an [F# Analyzer](https://medium.com/lambda-factory/introducing-f-analyzers-772487889429).  
  
 

--- a/src/CodeModel.fs
+++ b/src/CodeModel.fs
@@ -8,6 +8,10 @@ type DRange =
      StartColumn: int
      EndLine: int
      EndColumn: int }
+   override range.ToString() = 
+       sprintf "(%d,%d)-(%d-%d)" range.StartLine range.StartColumn range.EndLine range.EndColumn
+
+
 
 /// A representation of resolved F# expressions that can be serialized
 type DExpr = 
@@ -67,14 +71,24 @@ and DType =
 and DLocalDef = 
     { Name: string
       IsMutable: bool
-      Type: DType
+      LocalType: DType
       Range: DRange option
       IsCompilerGenerated: bool }
+
+and DFieldDef = 
+    { Name: string
+      IsStatic: bool
+      IsMutable: bool
+      FieldType: DType
+      Range: DRange option
+      IsCompilerGenerated: bool 
+    }
 
 and DMemberDef = 
     { EnclosingEntity: DEntityRef
       Name: string
       GenericParameters: DGenericParameterDef[]
+      IsOverride: bool
       IsInstance: bool
       IsValue: bool
       IsCompilerGenerated: bool
@@ -83,31 +97,39 @@ and DMemberDef =
       Range: DRange option }
 
     member x.Ref = 
-        { Entity=x.EnclosingEntity
-          Name= x.Name
-          GenericArity = x.GenericParameters.Length 
-          ArgTypes = (x.Parameters |> Array.map (fun p -> p.Type)) 
-          ReturnType = x.ReturnType 
+        { Key =
+            { Entity=x.EnclosingEntity
+              Name= x.Name
+              GenericArity = x.GenericParameters.Length 
+              ArgTypes = (x.Parameters |> Array.map (fun p -> p.LocalType)) 
+              ReturnType = x.ReturnType 
+            }
           Range = x.Range }
 
 and DGenericParameterDef = 
     { Name: string }
 
 and DEntityDef = 
-    { Name: string
+    { QualifiedName: string
+      NameX: string
       GenericParameters: DGenericParameterDef[]
       BaseType: DType option
+      DeclaredInterfaces: DType[]
+      DeclaredFields: DFieldDef[]
       UnionCases: string[]
       Range: DRange option }
 
 and DEntityRef = DEntityRef of string 
 
-and DMemberRef = 
+and DMemberRefKey = 
     { Entity: DEntityRef 
       Name: string
       GenericArity: int 
       ArgTypes: DType[] 
-      ReturnType: DType 
+      ReturnType: DType  }
+
+and DMemberRef = 
+    { Key: DMemberRefKey
       Range: DRange option }
 
 and DLocalRef = 

--- a/src/CodeModel.fs
+++ b/src/CodeModel.fs
@@ -96,6 +96,7 @@ and DGenericParameterDef =
 and DEntityDef = 
     { Name: string
       GenericParameters: DGenericParameterDef[]
+      BaseType: DType option
       UnionCases: string[]
       Range: DRange option }
 

--- a/src/FSharp.Compiler.PortaCode.fsproj
+++ b/src/FSharp.Compiler.PortaCode.fsproj
@@ -11,9 +11,9 @@
         <Compile Include="ProcessCommandLine.fs" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="4.5.2" />
+        <PackageReference Update="FSharp.Core" Version="4.7.2" />
         <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-        <PackageReference Include="FSharp.Compiler.Service"  Version="25.0.1" />
-        <PackageReference Include="Dotnet.ProjInfo"  Version="0.9.0" />
+        <PackageReference Include="FSharp.Compiler.Service"  Version="37.0.0" />
+        <PackageReference Include="Dotnet.ProjInfo"  Version="0.44.0" />
     </ItemGroup>
 </Project>

--- a/src/ProcessCommandLine.fs
+++ b/src/ProcessCommandLine.fs
@@ -22,7 +22,7 @@ let ProcessCommandLine (argv: string[]) =
     let mutable fsproj = None
     let mutable dump = false
     let mutable livecheck = false
-    let mutable dyncompile = false
+    let mutable dyntypes = false
     let mutable watch = true
     let mutable useEditFiles = false
     let mutable writeinfo = true
@@ -51,8 +51,8 @@ let ProcessCommandLine (argv: string[]) =
                     livecheck <- true
                     writeinfo <- true
                     useEditFiles <- true
-                elif arg = "--dyncompile" then 
-                    dyncompile <- true
+                elif arg = "--dyntypes" then 
+                    dyntypes <- true
                 elif arg.StartsWith "--send:" then webhook  <- Some arg.["--send:".Length ..]
                 elif arg = "--send" then webhook  <- Some defaultUrl
                 elif arg = "--version" then 
@@ -82,7 +82,7 @@ let ProcessCommandLine (argv: string[]) =
                    printfn "                     This uses on-demand execution semantics for top-level declarations"
                    printfn "                     Also write an info file based on results of evaluation."
                    printfn "                     Also watch for .fsharp/foo.fsx.edit files and use the contents of those in preference to the source file"
-                   printfn "   --dyncompile      Dynamically compile and load so full .NET types exist"
+                   printfn "   --dyntypes      Dynamically compile and load so full .NET types exist"
                    printfn "   <other-args>      All other args are assumed to be extra F# command line arguments, e.g. --define:FOO"
                    exit 1
                 else yield arg  |]
@@ -426,7 +426,7 @@ let ProcessCommandLine (argv: string[]) =
 
         assemblyNameId <- assemblyNameId + 1
         let assemblyName = AssemblyName("Eval" + string assemblyNameId)
-        let ctxt = EvalContext(assemblyName, dyncompile, assemblyResolver, ?sink=sink)
+        let ctxt = EvalContext(assemblyName, dyntypes, assemblyResolver, ?sink=sink)
         let fileConvContents = [| for i in fileContents -> convFile i |]
 
         for (_, contents) in fileConvContents do 
@@ -482,7 +482,7 @@ let ProcessCommandLine (argv: string[]) =
 
             if not dump && webhook.IsNone then 
                 //let dynAssembly =
-                //    if dyncompile then 
+                //    if dyntypes then 
                 //        produceDynamicAssembly parseTrees
                 //    else 
                 //        None

--- a/src/ProjectCracker.fs
+++ b/src/ProjectCracker.fs
@@ -3,17 +3,21 @@
 open System
 open System.IO
 open System.Collections.Concurrent
-open Microsoft.FSharp.Compiler.SourceCodeServices
+open FSharp.Compiler.SourceCodeServices
 
 module MSBuildPrj = Dotnet.ProjInfo.Inspect
 
 type NavigateProjectSM =
     | NoCrossTargeting of NoCrossTargetingData
     | CrossTargeting of string list
-and NoCrossTargetingData = { FscArgs: string list; P2PRefs: MSBuildPrj.ResolvedP2PRefsInfo list; Properties: Map<string,string> }
+and NoCrossTargetingData =
+    { FscArgs: string list
+      P2PRefs: MSBuildPrj.ResolvedP2PRefsInfo list
+      Properties: Map<string,string> }
 
 module MSBuildKnownProperties =
     let TargetFramework = "TargetFramework"
+    let DefineConstants = "DefineConstants"
 
 module Option =
   let getOrElse defaultValue option =
@@ -25,10 +29,6 @@ module Option =
 type FilePath = string
   [<RequireQualifiedAccess>]
 type ProjectSdkType =
-#if OLDFORMATS
-    | Verbose of ProjectSdkTypeVerbose
-    | ProjectJson
-#endif
     | DotnetSdk of ProjectSdkTypeDotnetSdk
 and ProjectSdkTypeVerbose =
     {
@@ -36,31 +36,13 @@ and ProjectSdkTypeVerbose =
     }
 and ProjectSdkTypeDotnetSdk =
     {
-      IsTestProject: bool
       Configuration: string // Debug
-      IsPackable: bool // true
       TargetFramework: string // netcoreapp1.0
-      TargetFrameworkIdentifier: string // .NETCoreApp
-      TargetFrameworkVersion: string // v1.0
-
-      MSBuildAllProjects: FilePath list //;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Sdks\FSharp.NET.Sdk\Sdk\Sdk.props;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Sdks\Microsoft.NET.Sdk\Sdk\Sdk.props;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.Sdk.props;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.Sdk.DefaultItems.props;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.SupportedTargetFrameworks.props;e:\github\DotnetNewFsprojTestingSamples\sdk1.0\sample1\c1\obj\c1.fsproj.nuget.g.props;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Sdks\FSharp.NET.Sdk\Sdk\Sdk.targets;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Sdks\Microsoft.NET.Sdk\Sdk\Sdk.targets;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.Sdk.BeforeCommon.targets;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.DefaultAssemblyInfo.targets;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.DefaultOutputPaths.targets;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.TargetFrameworkInference.targets;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.RuntimeIdentifierInference.targets;C:\Users\e.sada\.nuget\packages\fsharp.net.sdk\1.0.5\build\FSharp.NET.Core.Sdk.targets;e:\github\DotnetNewFsprojTestingSamples\sdk1.0\sample1\c1\c1.fsproj;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Microsoft.Common.CurrentVersion.targets;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\NuGet.targets;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\15.0\Microsoft.Common.targets\ImportAfter\Microsoft.TestPlatform.ImportAfter.targets;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Microsoft.TestPlatform.targets;e:\github\DotnetNewFsprojTestingSamples\sdk1.0\sample1\c1\obj\c1.fsproj.nuget.g.targets;e:\github\DotnetNewFsprojTestingSamples\sdk1.0\sample1\c1\obj\c1.fsproj.proj-info.targets;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.Sdk.targets;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.Sdk.Common.targets;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Sdks\Microsoft.NET.Sdk\build\Microsoft.PackageDependencyResolution.targets;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.Sdk.DefaultItems.targets;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.DisableStandardFrameworkResolution.targets;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.GenerateAssemblyInfo.targets;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.Publish.targets;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.PreserveCompilationContext.targets;C:\dotnetcli\dotnet-dev-win-x64.1.0.4\sdk\1.0.4\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets
-      MSBuildToolsVersion: string // 15.0
-
-      ProjectAssetsFile: FilePath // e:\github\DotnetNewFsprojTestingSamples\sdk1.0\sample1\c1\obj\project.assets.json
+      DefineConstants: string 
       RestoreSuccess: bool // True
-
       Configurations: string list // Debug;Release
       TargetFrameworks: string list // netcoreapp1.0;netstandard1.6
-
       TargetPath: string
-
-      //may not exists
-      RunArguments: string option // exec "e:\github\DotnetNewFsprojTestingSamples\sdk1.0\sample1\c1\bin\Debug\netcoreapp1.0\c1.dll"
-      RunCommand: string option // dotnet
-
-      //from 2.0
-      IsPublishable: bool option // true
-
     }
 type ExtraProjectInfoData =
     {
@@ -85,6 +67,7 @@ type ParsedProjectCache = ConcurrentDictionary<string, ParsedProject>
 let chooseByPrefix (prefix: string) (s: string) =
     if s.StartsWith(prefix) then Some (s.Substring(prefix.Length))
     else None
+
 let chooseByPrefix2 prefixes (s: string) =
     prefixes
     |> List.tryPick (fun prefix -> chooseByPrefix prefix s)
@@ -98,32 +81,31 @@ let splitByPrefix2 prefixes (s: string) =
     |> List.tryPick (fun prefix -> splitByPrefix prefix s)
 
 let outType rsp =
-      match List.tryPick (chooseByPrefix "--target:") rsp with
-      | Some "library" -> ProjectOutputType.Library
-      | Some "exe" -> ProjectOutputType.Exe
-      | Some v -> ProjectOutputType.Custom v
-      | None -> ProjectOutputType.Exe // default if arg is not passed to fsc
+    match List.tryPick (chooseByPrefix "--target:") rsp with
+    | Some "library" -> ProjectOutputType.Library
+    | Some "exe" -> ProjectOutputType.Exe
+    | Some v -> ProjectOutputType.Custom v
+    | None -> ProjectOutputType.Exe // default if arg is not passed to fsc
 
 let private outputFileArg = ["--out:"; "-o:"]
 
 let private makeAbs projDir (f: string) =
-      if Path.IsPathRooted f then f else Path.Combine(projDir, f)
+    if Path.IsPathRooted f then f else Path.Combine(projDir, f)
 
 let outputFile projDir rsp =
-      rsp
-      |> List.tryPick (chooseByPrefix2 outputFileArg)
-      |> Option.map (makeAbs projDir)
+    rsp
+    |> List.tryPick (chooseByPrefix2 outputFileArg)
+    |> Option.map (makeAbs projDir)
 
 let isCompileFile (s:string) =
-      s.EndsWith(".fs") || s.EndsWith (".fsi")
+    s.EndsWith(".fs") || s.EndsWith (".fsi")
 
 let compileFiles =
-      //TODO filter the one without initial -
-      List.filter isCompileFile
+    //TODO filter the one without initial -
+    List.filter isCompileFile
 
 let references =
-      //TODO valid also --reference:
-      List.choose (chooseByPrefix "-r:")
+    List.choose (chooseByPrefix "-r:")
 
 let useFullPaths projDir (s: string) =
     match s |> splitByPrefix2 outputFileArg with
@@ -160,47 +142,23 @@ let getExtraInfo targetPath props =
     let msbuildPropString prop =
         props |> Map.tryFind prop
 
-    { ProjectSdkTypeDotnetSdk.IsTestProject = msbuildPropBool "IsTestProject" |> Option.getOrElse false
-      Configuration = msbuildPropString "Configuration" |> Option.getOrElse ""
-      IsPackable = msbuildPropBool "IsPackable" |> Option.getOrElse false
+    { Configuration = msbuildPropString "Configuration" |> Option.getOrElse ""
       TargetFramework = msbuildPropString MSBuildKnownProperties.TargetFramework |> Option.getOrElse ""
-      TargetFrameworkIdentifier = msbuildPropString "TargetFrameworkIdentifier" |> Option.getOrElse ""
-      TargetFrameworkVersion = msbuildPropString "TargetFrameworkVersion" |> Option.getOrElse ""
+      DefineConstants = msbuildPropString MSBuildKnownProperties.DefineConstants |> Option.getOrElse ""
       TargetPath = targetPath
-
-      MSBuildAllProjects = msbuildPropStringList "MSBuildAllProjects" |> Option.getOrElse []
-      MSBuildToolsVersion = msbuildPropString "MSBuildToolsVersion" |> Option.getOrElse ""
-
-      ProjectAssetsFile = msbuildPropString "ProjectAssetsFile" |> Option.getOrElse ""
       RestoreSuccess = msbuildPropBool "RestoreSuccess" |> Option.getOrElse false
-
       Configurations = msbuildPropStringList "Configurations" |> Option.getOrElse []
-      TargetFrameworks = msbuildPropStringList "TargetFrameworks" |> Option.getOrElse []
-
-      RunArguments = msbuildPropString "RunArguments"
-      RunCommand = msbuildPropString "RunCommand"
-
-      IsPublishable = msbuildPropBool "IsPublishable" }
+      TargetFrameworks = msbuildPropStringList "TargetFrameworks" |> Option.getOrElse [] }
 
 let (|MsbuildOk|_|) x =
     match x with
-#if NETSTANDARD2_0
     | Ok x -> Some x
     | Error _ -> None
-#else
-    | Choice1Of2 x -> Some x
-    | Choice2Of2 _ -> None
-#endif
 
 let (|MsbuildError|_|) x =
     match x with
-#if NETSTANDARD2_0
     | Ok _ -> None
     | Error x -> Some x
-#else
-    | Choice1Of2 _ -> None
-    | Choice2Of2 x -> Some x
-#endif
 
 let runProcess (log: string -> unit) (workingDir: string) (exePath: string) (args: string) =
     let psi = System.Diagnostics.ProcessStartInfo()
@@ -219,7 +177,7 @@ let runProcess (log: string -> unit) (workingDir: string) (exePath: string) (arg
 
     p.ErrorDataReceived.Add(fun ea -> log (ea.Data))
 
-    // printfn "running: %s %s" psi.FileName psi.Arguments
+    printfn "running: %s %s" psi.FileName psi.Arguments
 
     p.Start() |> ignore
     p.BeginOutputReadLine()
@@ -231,75 +189,45 @@ let runProcess (log: string -> unit) (workingDir: string) (exePath: string) (arg
     exitCode, (workingDir, exePath, args)
 
 
-let private getProjectOptionsFromProjectFile (cache: ParsedProjectCache) parseAsSdk (file : string) =
+let private getProjectOptionsFromProjectFile (cache: ParsedProjectCache) parseAsSdk (file : string) msbuildArgs =
 
     let rec projInfoOf additionalMSBuildProps (file: string) : ParsedProject =
         let projDir = Path.GetDirectoryName file
-
-        //notifyState (WorkspaceProjectState.Loading file)
 
         match parseAsSdk with
         | ProjectParsingSdk.DotnetSdk ->
             let projectAssetsJsonPath = Path.Combine(projDir, "obj", "project.assets.json")
             if not(File.Exists(projectAssetsJsonPath)) then
                 failwithf "project '%s' not restored" file
-#if OLDFORMATS
-        | ProjectParsingSdk.VerboseSdk ->
-            ()
-#endif
 
         let getFscArgs =
             match parseAsSdk with
             | ProjectParsingSdk.DotnetSdk ->
                 Dotnet.ProjInfo.Inspect.getFscArgs
-#if OLDFORMATS
-            | ProjectParsingSdk.VerboseSdk ->
-                let asFscArgs props =
-                    let fsc = Microsoft.FSharp.Build.Fsc()
-                    Dotnet.ProjInfo.FakeMsbuildTasks.getResponseFileFromTask props fsc
-                let ok =
-#if NETSTANDARD2_0
-                    Ok
-#else
-                    Choice1Of2
-#endif
-                Dotnet.ProjInfo.Inspect.getFscArgsOldSdk (asFscArgs >> ok)
-#endif
 
         let getP2PRefs = Dotnet.ProjInfo.Inspect.getResolvedP2PRefs
         let additionalInfo = //needed for extra
             [ "OutputType"
-              "IsTestProject"
               "Configuration"
-              "IsPackable"
               MSBuildKnownProperties.TargetFramework
-              "TargetFrameworkIdentifier"
-              "TargetFrameworkVersion"
-              "MSBuildAllProjects"
-              "ProjectAssetsFile"
               "RestoreSuccess"
               "Configurations"
               "TargetFrameworks"
-              "RunArguments"
-              "RunCommand"
-              "IsPublishable"
             ]
         let gp () = Dotnet.ProjInfo.Inspect.getProperties (["TargetPath"; "IsCrossTargetingBuild"; "TargetFrameworks"] @ additionalInfo)
 
         let results, log =
             let loggedMessages = System.Collections.Concurrent.ConcurrentQueue<string>()
 
-            let runCmd exePath args = runProcess loggedMessages.Enqueue projDir exePath (args |> String.concat " ")
+            let runCmd exePath args =
+                let args = args @ msbuildArgs
+                runProcess loggedMessages.Enqueue projDir exePath (args |> String.concat " ")
 
             let msbuildExec =
                 let msbuildPath =
                     match parseAsSdk with
                     | ProjectParsingSdk.DotnetSdk ->
                         Dotnet.ProjInfo.Inspect.MSBuildExePath.DotnetMsbuild "dotnet"
-#if OLDFORMATS
-                    | ProjectParsingSdk.VerboseSdk ->
-                        Dotnet.ProjInfo.Inspect.MSBuildExePath.Path "msbuild"
-#endif
                 Dotnet.ProjInfo.Inspect.msbuild msbuildPath runCmd
 
             let additionalArgs = additionalMSBuildProps |> List.map (Dotnet.ProjInfo.Inspect.MSBuild.MSbuildCli.Property)
@@ -308,10 +236,6 @@ let private getProjectOptionsFromProjectFile (cache: ParsedProjectCache) parseAs
                 match parseAsSdk with
                 | ProjectParsingSdk.DotnetSdk ->
                     Dotnet.ProjInfo.Inspect.getProjectInfos
-#if OLDFORMATS
-                | ProjectParsingSdk.VerboseSdk ->
-                    Dotnet.ProjInfo.Inspect.getProjectInfosOldSdk
-#endif
 
             let infoResult =
                 file
@@ -392,14 +316,6 @@ let private getProjectOptionsFromProjectFile (cache: ParsedProjectCache) parseAs
                 | ProjectParsingSdk.DotnetSdk ->
                     let extraInfo = getExtraInfo tar props
                     ProjectSdkType.DotnetSdk(extraInfo), []
-#if OLDFORMATS
-                | ProjectParsingSdk.VerboseSdk ->
-                    //compatibility with old behaviour, so output is exactly the same
-                    let mergedLog =
-                        [ yield (file, "")
-                          yield! p2pProjects |> List.collect (fun (_,_,x) -> x) ]
-                    ProjectSdkType.Verbose { TargetPath = tar }, mergedLog
-#endif
 
             let po =
                 {
@@ -445,36 +361,20 @@ let private (|ProjectExtraInfoBySdk|_|) po =
               Some extraInfo
           | _ -> None
 
-let private loadBySdk (cache: ParsedProjectCache) parseAsSdk file =
-        let po, log = getProjectOptionsFromProjectFile cache parseAsSdk file
+let private loadBySdk (cache: ParsedProjectCache) parseAsSdk msbuildArgs file =
+    let po, log = getProjectOptionsFromProjectFile cache parseAsSdk msbuildArgs file
 
-        let compileFiles =
-            let sources = compileFiles (po.OtherOptions |> List.ofArray)
-            match po with
-            | ProjectExtraInfoBySdk extraInfo ->
-                match extraInfo.ProjectSdkType with
-#if OLDFORMATS
-                | ProjectSdkType.Verbose _ ->
-                    //compatibility with old behaviour (projectcracker), so test output is exactly the same
-                    //the temp source files (like generated assemblyinfo.fs) are not added to sources
-                    let isTempFile (name: string) =
-                        let tempPath = Path.GetTempPath()
-                        let s = name.ToLower()
-                        s.StartsWith(tempPath.ToLower())
-                    sources
-                    |> List.filter (not << isTempFile)
-                | ProjectSdkType.ProjectJson
-#endif
-                | ProjectSdkType.DotnetSdk _ ->
-                    sources
-            | _ -> sources
+    let compileFiles =
+        let sources = compileFiles (po.OtherOptions |> List.ofArray)
+        match po with
+        | ProjectExtraInfoBySdk extraInfo ->
+            match extraInfo.ProjectSdkType with
+            | ProjectSdkType.DotnetSdk _ ->
+                sources
+        | _ -> sources
 
-        Ok (po, Seq.toList compileFiles, (log |> Map.ofList))
+    Ok (po, Seq.toList compileFiles, (log |> Map.ofList))
 
-let load (cache: ParsedProjectCache) file =
-      loadBySdk cache ProjectParsingSdk.DotnetSdk file
+let load (cache: ParsedProjectCache) msbuildArgs file =
+      loadBySdk cache ProjectParsingSdk.DotnetSdk msbuildArgs file
 
-#if OLDFORMATS
-let loadVerboseSdk (cache: ParsedProjectCache) file =
-      loadBySdk cache ProjectParsingSdk.VerboseSdk file
-#endif

--- a/tests/FsLive.Cli.Tests.fsproj
+++ b/tests/FsLive.Cli.Tests.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <OutputType>Library</OutputType>
         <IsPackable>false</IsPackable>
         <DefineConstants>$(DefineConstants);NETSTANDARD2_0;TEST</DefineConstants>

--- a/tests/PortaCodeTests.fs
+++ b/tests/PortaCodeTests.fs
@@ -265,7 +265,7 @@ module PlusOperator =
 [<TestCase(true)>]
 //[<TestCase(false)>] // this only works with dyntypes
 let ImplementClassOverride(dyntypes: bool) =
-    SimpleTestCase false dyntypes "SetMapCount" """
+    SimpleTestCase false dyntypes "ImplementClassOverride" """
 
 type UserType() =
     override x.ToString() = "a"
@@ -278,12 +278,27 @@ f()
 """
 
 
+//[<TestCase(true)>]
+////[<TestCase(false)>] // this only works with dyntypes
+//let ImplementClassOverrideInGenericClass(dyntypes: bool) =
+//    SimpleTestCase false dyntypes "ImplementClassOverrideInGenericClass" """
+
+//type UserType<'T>(x:'T) =
+//    override _.ToString() : string = unbox x
+//let f () = 
+//    let u : UserType<string> = UserType<string>("a")
+//    let s = u.ToString()
+//    if s <> "a" then failwithf "unexpected, got '%s', expected 'a'" s 
+
+//f()
+//"""
+
+
 [<TestCase(true)>]
 [<TestCase(false)>]
 let SetMapCount(dyntypes: bool) =
     SimpleTestCase false dyntypes "SetMapCount" """
 
-type UserType = A of int | B
 let f () = 
     let l = [ 1; 2; 3 ]
     let s = Set.ofList [ 1; 2; 3 ]
@@ -291,6 +306,17 @@ let f () =
     if l.Length <> 3 then failwith "unexpected"
     if s.Count <> 3 then failwith "unexpected"
     if m.Count <> 1 then failwith "unexpected"
+
+f()
+"""
+
+[<TestCase(true)>]
+[<TestCase(false)>]
+let ArrayOfUserDefinedUnionType(dyntypes: bool) =
+    SimpleTestCase false dyntypes "ArrayOfUserDefinedUnionType" """
+
+type UserType = A of int | B
+let f () = 
     let a = [| UserType.A 1 |]
     if a.Length <> 1 then failwith "unexpected"
 
@@ -299,8 +325,34 @@ f()
 
 [<TestCase(true)>]
 [<TestCase(false)>]
+let ArrayOfUserDefinedRecordType(dyntypes: bool) =
+    SimpleTestCase false dyntypes "ArrayOfUserDefinedUnionRecordType" """
+
+type UserType = { X: int; Y: string }
+let f () = 
+    let a = [| { X = 1; Y = "a" } |]
+    if a.Length <> 1 then failwith "unexpected"
+
+f()
+"""
+
+[<TestCase(true)>]
+[<TestCase(false)>]
+let SetOfUserDefinedUnionType(dyntypes: bool) =
+    SimpleTestCase false dyntypes "SetOfUserDefinedUnionType" """
+
+type UserType = A of int | B
+let f () = 
+    let a = set [| UserType.A 1 |]
+    if a.Count <> 1 then failwith "unexpected"
+
+f()
+"""
+
+[<TestCase(true)>]
+[<TestCase(false)>]
 let MinusOperator (dyntypes: bool) =
-        SimpleTestCase false dyntypes "MinusOperator" """
+    SimpleTestCase false dyntypes "MinusOperator" """
 module MinusOperator = 
     let x1 = 1 - 1
     let x5 = 1.0 - 2.0
@@ -319,7 +371,7 @@ module MinusOperator =
 [<TestCase(true)>]
 [<TestCase(false)>]
 let Options (dyntypes: bool) =
-        SimpleTestCase false dyntypes "Options" """
+    SimpleTestCase false dyntypes "Options" """
 module Options = 
     let x2 = None : int option 
     let x3 = Some 3 : int option 
@@ -332,7 +384,7 @@ module Options =
 [<TestCase(true)>]
 [<TestCase(false)>]
 let Exceptions (dyntypes: bool) =
-        SimpleTestCase false dyntypes "Exceptions" """
+    SimpleTestCase false dyntypes "Exceptions" """
 module Exceptions = 
     let x2 = try invalidArg "a" "wtf" with :? System.ArgumentException -> () 
     let x4 = try failwith "hello" with e -> () 
@@ -343,14 +395,14 @@ module Exceptions =
 [<TestCase(true)>]
 [<TestCase(false)>]
 let TestEvalIsNone (dyntypes: bool) =
-        SimpleTestCase false dyntypes "TestEvalIsNone" """
+    SimpleTestCase false dyntypes "TestEvalIsNone" """
 let x3 = (Some 3).IsNone
         """
 
 [<TestCase(true)>]
 [<TestCase(false)>]
 let TestEvalUnionCaseInGenericCode (dyntypes: bool) =
-        SimpleTestCase false dyntypes "TestEvalUnionCaseInGenericCofe" """
+    SimpleTestCase false dyntypes "TestEvalUnionCaseInGenericCofe" """
 let f<'T>(x:'T) = Some x
 
 let y = f 3
@@ -359,7 +411,7 @@ printfn "y = %A, y.GetType() = %A" y (y.GetType())
 [<TestCase(true)>]
 [<TestCase(false)>]
 let TestEvalNewOnClass(dyntypes: bool) =
-        SimpleTestCase false dyntypes "TestEvalNewOnClass" """
+    SimpleTestCase false dyntypes "TestEvalNewOnClass" """
 type C(x: int) = 
     member __.X = x
 
@@ -370,7 +422,7 @@ let z = if y.X <> 3 then failwith "fail!" else 1
 [<TestCase(true)>]
 [<TestCase(false)>]
 let TestExtrinsicFSharpExtensionOnClass1(dyntypes: bool) =
-        SimpleTestCase false dyntypes "TestExtrinsicFSharpExtensionOnClass1" """
+    SimpleTestCase false dyntypes "TestExtrinsicFSharpExtensionOnClass1" """
 type System.String with 
     member x.GetLength() = x.Length
 
@@ -381,7 +433,7 @@ let z = if y <> 1 then failwith "fail!" else 1
 [<TestCase(true)>]
 [<TestCase(false)>]
 let TestExtrinsicFSharpExtensionOnClass2(dyntypes: bool) =
-        SimpleTestCase false dyntypes "TestExtrinsicFSharpExtensionOnClass2" """
+    SimpleTestCase false dyntypes "TestExtrinsicFSharpExtensionOnClass2" """
 type System.String with 
     member x.GetLength2(y:int) = x.Length + y
 
@@ -392,7 +444,7 @@ let z = if y <> 7 then failwith "fail!" else 1
 [<TestCase(true)>]
 [<TestCase(false)>]
 let TestExtrinsicFSharpExtensionOnClass3(dyntypes: bool) =
-        SimpleTestCase false dyntypes "TestExtrinsicFSharpExtensionOnClass3" """
+    SimpleTestCase false dyntypes "TestExtrinsicFSharpExtensionOnClass3" """
 type System.String with 
     static member GetLength3(x:string) = x.Length
 
@@ -403,7 +455,7 @@ let z = if y <> 3 then failwith "fail!" else 1
 [<TestCase(true)>]
 [<TestCase(false)>]
 let TestExtrinsicFSharpExtensionOnClass4(dyntypes: bool) =
-        SimpleTestCase false dyntypes "TestExtrinsicFSharpExtensionOnClass4" """
+    SimpleTestCase false dyntypes "TestExtrinsicFSharpExtensionOnClass4" """
 type System.String with 
     member x.LengthProp = x.Length
 
@@ -414,7 +466,7 @@ let z = if y <> 4 then failwith "fail!" else 1
 [<TestCase(true)>]
 [<TestCase(false)>]
 let TestTopMutables(dyntypes: bool) =
-        SimpleTestCase false dyntypes "TestTopFunctionIsNotValue" """
+    SimpleTestCase false dyntypes "TestTopFunctionIsNotValue" """
 let mutable x = 0
 if x <> 0 then failwith "failure A!" else 1
 let y(c:int) = 
@@ -430,7 +482,7 @@ if z1 <> 1 || z2 <> 2 then failwith "failure D!" else 1
 [<TestCase(true)>]
 [<TestCase(false)>]
 let TestTopFunctionIsNotValue(dyntypes: bool) =
-        SimpleTestCase false dyntypes "TestTopFunctionIsNotValue" """
+    SimpleTestCase false dyntypes "TestTopFunctionIsNotValue" """
 let mutable x = 0
 if x <> 0 then failwith "failure A!" else 1
 let y(c:int) = 
@@ -446,7 +498,7 @@ if z1 <> 1 || z2 <> 2 then failwith "failure D!" else 1
 [<TestCase(true)>]
 [<TestCase(false)>]
 let TestTopUnitValue(dyntypes: bool) =
-        SimpleTestCase false dyntypes "TestTopUnitValue" """
+    SimpleTestCase false dyntypes "TestTopUnitValue" """
 let mutable x = 0
 if x <> 0 then failwith "fail!" 
         """
@@ -454,7 +506,7 @@ if x <> 0 then failwith "fail!"
 [<TestCase(true)>]
 [<TestCase(false)>]
 let TestEvalSetterOnClass(dyntypes: bool) =
-        SimpleTestCase false dyntypes "TestEvalSetterOnClass" """
+    SimpleTestCase false dyntypes "TestEvalSetterOnClass" """
 type C(x: int) = 
     let mutable y = x
     member __.Y with get() = y and set v = y <- v
@@ -470,14 +522,14 @@ if c.Y <> 4 then failwith "fail! fail!"
 [<TestCase(true)>]
 [<TestCase(false)>]
 let TestLengthOnList(dyntypes: bool) =
-        SimpleTestCase false dyntypes "TestLengthOnList" """
+    SimpleTestCase false dyntypes "TestLengthOnList" """
 let x = [1;2;3].Length
 if x <> 3 then failwith "fail! fail!" 
         """
 // Known limitation of FSharp Compiler Service
 //[<Test>]
 //    let TestEvalLocalFunctionOnClass() =
-//        SimpleTestCase false dyntypes "TestEvalLocalFunctionOnClass" """
+//    SimpleTestCase false dyntypes "TestEvalLocalFunctionOnClass" """
 //type C(x: int) = 
 //    let f x = x + 1
 //    member __.Y with get() = f x
@@ -489,7 +541,7 @@ if x <> 3 then failwith "fail! fail!"
 [<TestCase(true)>]
 [<TestCase(false)>]
 let TestEquals(dyntypes: bool) =
-        SimpleTestCase false dyntypes "TestEquals" """
+    SimpleTestCase false dyntypes "TestEquals" """
 let x = (1 = 2)
         """
 
@@ -497,7 +549,7 @@ let x = (1 = 2)
 [<TestCase(true)>]
 [<TestCase(false)>]
 let TestTypeTest(dyntypes: bool) =
-        SimpleTestCase false dyntypes "TestTypeTest" """
+    SimpleTestCase false dyntypes "TestTypeTest" """
 let x = match box 1 with :? int as a -> a | _ -> failwith "fail!"
 if x <> 1 then failwith "fail fail!" 
         """
@@ -506,7 +558,7 @@ if x <> 1 then failwith "fail fail!"
 [<TestCase(true)>]
 [<TestCase(false)>]
 let TestTypeTest2(dyntypes: bool) =
-        SimpleTestCase false dyntypes "TestTypeTest2" """
+    SimpleTestCase false dyntypes "TestTypeTest2" """
 let x = match box 2 with :? string as a -> failwith "fail!" | _ -> 1
 if x <> 1 then failwith "fail fail!" 
         """
@@ -514,7 +566,7 @@ if x <> 1 then failwith "fail fail!"
 // Known limitation of FSharp Compiler Service
 //[<Test>]
 //    let GenericThing() =
-//        SimpleTestCase false dyntypes "GenericThing" """
+//    SimpleTestCase false dyntypes "GenericThing" """
 //let f () = 
 //    let g x = x
 //    g 3, g 4, g
@@ -527,7 +579,7 @@ if x <> 1 then failwith "fail fail!"
 [<TestCase(true)>]
 [<TestCase(false)>]
 let DateTime(dyntypes: bool) =
-        SimpleTestCase false dyntypes "DateTime" """
+    SimpleTestCase false dyntypes "DateTime" """
 let v1 = System.DateTime.Now
 let v2 = v1.Date
 let mutable v3 = System.DateTime.Now
@@ -537,7 +589,7 @@ let v4 = v3.Date
 [<TestCase(true)>]
 [<TestCase(false)>]
 let LocalMutation(dyntypes: bool) =
-        SimpleTestCase false dyntypes "LocalMutation" """
+    SimpleTestCase false dyntypes "LocalMutation" """
 let f () = 
     let mutable x = 1
     x <- x + 1
@@ -550,7 +602,7 @@ if f() <> 3 then failwith "fail fail!"
 [<TestCase(true)>]
 [<TestCase(false)>]
 let SimpleInheritFromObj(dyntypes: bool) =
-        SimpleTestCase false dyntypes "SimpleInheritFromObj" """
+    SimpleTestCase false dyntypes "SimpleInheritFromObj" """
 type C() =
     inherit obj()
     member val x = 1 with get, set
@@ -563,8 +615,8 @@ if c.x <> 3 then failwith "fail fail!"
 
 [<TestCase(true)>]
 [<TestCase(false)>]
-let SimpleInheritFroConcreteClass(dyntypes: bool) =
-        SimpleTestCase false dyntypes "SimpleInheritFromObj" """
+let SimpleInheritFromConcreteClass(dyntypes: bool) =
+    SimpleTestCase false dyntypes "SimpleInheritFromObj" """
 type C() =
     inherit System.Text.ASCIIEncoding()
     member val x = 1 with get, set
@@ -577,21 +629,134 @@ if c.CodePage  <> System.Text.ASCIIEncoding().CodePage then failwith "nope"
 [<TestCase(true)>]
 //[<TestCase(false)>]  this fails without dynamic types
 let SimpleInterfaceImpl(dyntypes) =
-        SimpleTestCase false dyntypes "SimpleInterfaceImpl" """
+    SimpleTestCase false dyntypes "SimpleInterfaceImpl" """
 open System
 type C() =
     interface IComparable with
-       member x.CompareTo(y:obj) = 2
+       member x.CompareTo(y:obj) = 17
 
 let c = C()
-if (c :> IComparable).CompareTo(c) <> 1 then failwith "fail fail!" 
+let v = (c :> IComparable).CompareTo(c)
+if v <> 17 then failwithf "fail fail! expected 17, got %d"  v
         """
 
 
 [<TestCase(true)>]
 //[<TestCase(false)>]  this fails without dynamic types
-let SimpleInterfaceImplPassedAsArg(dyntypes) =
-        SimpleTestCase false dyntypes "SimpleInterfaceImpl" """
+let SimpleInterfaceImpl2(dyntypes) =
+    SimpleTestCase false dyntypes "SimpleInterfaceImpl" """
+open System.Collections
+open System.Collections.Generic
+type C() =
+    interface IEnumerator with
+       member x.MoveNext() = false
+       member x.Current = box 1
+       member x.Reset() = ()
+
+let c = C() :> IEnumerator
+if c.MoveNext() <> false then failwith "fail fail!" 
+        """
+ 
+[<TestCase(true, Ignore="fails due to strange reflection emit problem for interface impls in generic classes"); >]
+[<TestCase(false, Ignore= "fails without dynamic emit types")>]
+let SimpleInterfaceImplGenericClass(dyntypes) =
+    SimpleTestCase false dyntypes "SimpleInterfaceImpl" """
+open System.Collections
+open System.Collections.Generic
+type C<'T>() =
+    interface IEnumerator with
+       member x.MoveNext() = false
+       member x.Current = box 1
+       member x.Reset() = ()
+
+let c = C<int>() :> IEnumerator
+if c.MoveNext() <> false then failwith "fail fail!" 
+        """
+ 
+[<TestCase(true)>]
+[<TestCase(false, Ignore= "fails without dynamic emit types")>]
+let SimpleGenericInterfaceImpl(dyntypes) =
+    SimpleTestCase false dyntypes "SimpleInterfaceImpl" """
+open System.Collections
+open System.Collections.Generic
+type C() =
+    interface IEnumerator<int> with
+       member x.Current = 17
+       member x.Dispose() = ()
+    interface IEnumerator with
+       member x.MoveNext() = false
+       member x.Current = box 10
+       member x.Reset() = ()
+
+let c = new C() :> IEnumerator<int>
+if c.Current <> 17 then failwith "fail fail!" 
+if c.Reset() <> () then failwith "fail fail 2!" 
+if c.MoveNext() <> false then failwith "fail fail!" 
+        """
+ 
+[<TestCase(true, Ignore= "ignore because union types don't get dynamic emit types yet, codegen is too complicated and FCS doesn't tell us how") >]
+[<TestCase(false, Ignore= "fails without dynamic emit types")>]
+let UnionTypeWithOverride(dyntypes) =
+    SimpleTestCase false dyntypes "UnionTypeWithOverride" """
+
+type UnionType =
+   | A
+   | B
+   override x.ToString() = "dd"
+
+if A.ToString() <> "dd" then failwith "fail fail! 1" 
+        """
+
+[<TestCase(true) >]
+[<TestCase(false)>]
+let SimpleClass(dyntypes) =
+    SimpleTestCase false dyntypes "SimpleClass" """
+
+type C(x: int, y: int) =
+    member _.X = x
+    member _.Y = y
+    member _.XY = x + y
+
+let c = C(3,4)
+if c.X <> 3 then failwith "fail fail! 1" 
+if c.Y <> 4 then failwith "fail fail! 2" 
+if c.XY <> 7 then failwith "fail fail! 3" 
+        """
+
+[<TestCase(true) >]
+[<TestCase(false)>]
+let SimpleClassWithInnerFunctions(dyntypes) =
+    SimpleTestCase false dyntypes "SimpleClass" """
+
+type C(x: int, y: int) =
+    let f x = x + 1
+    member _.FX = f x
+
+let c = C(3,4)
+if c.FX <> 4 then failwith "fail fail! 4" 
+        """
+
+[<TestCase(true) >]
+[<TestCase(false)>]
+let SimpleStruct(dyntypes) =
+    SimpleTestCase false dyntypes "SimpleStruct" """
+
+[<Struct>]
+type C(x: int, y: int) =
+    member _.X = x
+    member _.Y = y
+    member _.XY = x + y
+
+let c = C(3,4)
+if c.X <> 3 then failwith "fail fail! 1" 
+if c.Y <> 4 then failwith "fail fail! 2" 
+if c.XY <> 7 then failwith "fail fail! 3" 
+        """
+
+[<TestCase(true)>]
+[<TestCase(false, Ignore= "fails without dynamic emit types")>]
+let SimpleGenericInterfaceImplPassedAsArg(dyntypes) =
+    SimpleTestCase false dyntypes "SimpleGenericInterfaceImplPassedAsArg" """
 open System.Collections
 open System.Collections.Generic
 type C() =
@@ -614,7 +779,7 @@ if c.Length <> 0 then failwith "fail fail!"
 [<TestCase(true)>]
 [<TestCase(false)>]
 let LetRecSmoke(dyntypes: bool) =
-        SimpleTestCase false dyntypes "LetRecSmoke" """
+    SimpleTestCase false dyntypes "LetRecSmoke" """
 let even a = 
     let rec even x = (if x = 0 then true else odd (x-1))
     and odd x = (if x = 0 then false else even (x-1))
@@ -624,25 +789,25 @@ if even 11 then failwith "fail!"
 if not (even 10) then failwith "fail fail!" 
         """
 
-(*
-[<Test>]
-    let TraitCallSmoke() =
-        SimpleTestCase false dyntypes "TraitCallSmoke" """
-let even a = 
-    let rec even x = (if x = 0 then true else odd (x-1))
-    and odd x = (if x = 0 then false else even (x-1))
-    even a
+[<TestCase(true)>]
+[<TestCase(false)>]
+let FastIntegerForLoop(dyntypes: bool) =
+    SimpleTestCase false dyntypes "FastIntegerForLoop" """
 
-if even 11 then failwith "fail!" 
-if not (even 10) then failwith "fail fail!" 
+let f () = 
+    let mutable res = 0
+    for i in 0 .. 10 do
+       res <- res + i
+    res
+
+if f() <> List.sum [ 0 .. 10 ] then failwith "fail!" 
         """
-*)
 
 
 [<TestCase(true)>]
 [<TestCase(false)>]
 let TryGetValueSmoke(dyntypes: bool) =
-        SimpleTestCase false dyntypes "TryGetValueSmoke" """
+    SimpleTestCase false dyntypes "TryGetValueSmoke" """
 let m = dict  [ (1,"2") ]
 let f() = 
     match m.TryGetValue 1 with
@@ -655,7 +820,7 @@ f()
 [<TestCase(true)>]
 [<TestCase(false)>]
 let TestCallUnitFunction(dyntypes: bool) =
-        SimpleTestCase false dyntypes "TestCallUnitFunction" """
+    SimpleTestCase false dyntypes "TestCallUnitFunction" """
 let theRef = FSharp.Core.LanguagePrimitives.GenericZeroDynamic<int>()
        """
 


### PR DESCRIPTION
This adds a capability to use RefEmit to dynamically emit "shell types" that implement the virtual slots and thunk back into the interpreter.

This is for cases where the aim is to use the interpreter to supervise and observe execution, e.g. to capture the values of variables flowing through the computation, and to only execute live checks, but where better fidelity with .NET semantics is required.  The same could likely be achieved by rewriting .NET IL to intercept, or by using the .NET Core Debug API 

