### PR TITLE
Complete operators, allow LiveCheck on types with Invoke checker

### DIFF
--- a/src/CodeModel.fs
+++ b/src/CodeModel.fs
@@ -96,6 +96,7 @@ and DMemberDef =
       IsInstance: bool
       IsValue: bool
       IsCompilerGenerated: bool
+      CustomAttributes: DCustomAttributeDef[]
       Parameters: DLocalDef[]
       ReturnType: DType
       Range: DRange option }

--- a/src/CodeModel.fs
+++ b/src/CodeModel.fs
@@ -9,10 +9,25 @@ type DRange =
      EndLine: int
      EndColumn: int }
    override range.ToString() = 
-       sprintf "(%d,%d)-(%d-%d)" range.StartLine range.StartColumn range.EndLine range.EndColumn
+       sprintf "%s: (%d,%d)-(%d-%d)" range.File range.StartLine range.StartColumn range.EndLine range.EndColumn
 
+type DDiagnostic =
+   { Severity: int
+     Number: int
+     Message: string
+     Stack: DRange list }
 
-
+   override diag.ToString() = 
+       let sev = match diag.Severity with 0 -> "info" | 1 -> "warning" | _ -> "error"
+       match List.rev diag.Stack with 
+       | [] -> 
+           sprintf "%s LC%d: %O" sev diag.Number diag.Message
+       | loc:: t -> 
+           [ sprintf "%O: %s LC%d: %O" loc sev diag.Number diag.Message
+             for loc in t do
+                 sprintf "    stack: %O" loc ]
+           |> String.concat "\n"
+             
 /// A representation of resolved F# expressions that can be serialized
 type DExpr = 
     | Value  of DLocalRef
@@ -131,7 +146,9 @@ and DEntityDef =
 and DCustomAttributeDef =
     { AttributeType: DEntityRef
       ConstructorArguments: (DType * obj)[]
-      NamedArguments: (DType * string * bool * obj)[] }
+      NamedArguments: (DType * string * bool * obj)[]
+     // Range: DRange option 
+     }
 
 and DEntityRef = DEntityRef of string 
 
@@ -146,6 +163,7 @@ and DLocalRef =
     { Name: string
       IsThisValue: bool
       IsMutable: bool
+      IsCompilerGenerated: bool
       Range: DRange option }
 
 and DFieldRef = DFieldRef of int * string

--- a/src/FromCompilerService.fs
+++ b/src/FromCompilerService.fs
@@ -239,6 +239,7 @@ type Convert(includeRanges: bool) =
         assert (memb.IsMember || memb.IsModuleValueOrMember)
         { EnclosingEntity = convEntityRef memb.DeclaringEntity.Value
           ImplementedSlots = memb.ImplementedAbstractSignatures |> Seq.toArray |> Array.map convSlot
+          CustomAttributes = memb.Attributes |> Seq.toArray |> Array.map convCustomAttribute 
           Name = memb.CompiledName
           GenericParameters = convGenericParamDefs memb.GenericParameters
           Parameters = convParamDefs memb

--- a/src/FromCompilerService.fs
+++ b/src/FromCompilerService.fs
@@ -233,6 +233,7 @@ type Convert(includeRanges: bool) =
         { Name = value.CompiledName
           IsThisValue = (value.IsMemberThisValue || value.IsConstructorThisValue || value.IsBaseValue)
           IsMutable = value.IsMutable
+          IsCompilerGenerated = value.IsCompilerGenerated
           Range = convRange range }
 
     and convMemberDef (memb: FSharpMemberOrFunctionOrValue) : DMemberDef = 
@@ -325,6 +326,7 @@ type Convert(includeRanges: bool) =
         { AttributeType = convEntityRef cattr.AttributeType
           ConstructorArguments = cattr.ConstructorArguments |> Seq.toArray |> Array.map (fun (ty, v) -> convType ty, v)
           NamedArguments = cattr.NamedArguments |> Seq.toArray |> Array.map (fun (ty, v1, v2, v3) -> convType ty, v1, v2, v3)
+          //Range = cattr
           }
     and convEntityDef (entity: FSharpEntity) : DEntityDef = 
         if entity.IsNamespace then failwith "convEntityDef: can't convert a namespace"

--- a/src/Interpreter.fs
+++ b/src/Interpreter.fs
@@ -668,7 +668,7 @@ type EvalContext (assemblyName: AssemblyName, ?dyntypes: bool, ?assemblyResolver
 
     let rec instantiateType (typeArgs: Type[]) (ty: Type) = 
         if ty.IsGenericType then 
-            ty.MakeGenericType(Array.map (instantiateType typeArgs) (ty.GetGenericArguments()))
+            ty.GetGenericTypeDefinition().MakeGenericType(Array.map (instantiateType typeArgs) (ty.GetGenericArguments()))
         elif ty.IsArray then
             (instantiateType typeArgs (ty.GetElementType())).MakeArrayType(ty.GetArrayRank())
         elif ty.IsByRef then

--- a/src/Interpreter.fs
+++ b/src/Interpreter.fs
@@ -61,6 +61,28 @@ and ResolvedMember =
     | RPrim_checked_char
     | RPrim_checked_minus
     | RPrim_checked_mul
+    | RPrim_abs
+    | RPrim_acos
+    | RPrim_asin
+    | RPrim_atan
+    | RPrim_atan2
+    | RPrim_ceil
+    | RPrim_exp
+    | RPrim_floor
+    | RPrim_truncate
+    | RPrim_round
+    | RPrim_sign
+    | RPrim_log
+    | RPrim_log10
+    | RPrim_sqrt
+    | RPrim_cos
+    | RPrim_cosh
+    | RPrim_sin
+    | RPrim_sinh
+    | RPrim_tan
+    | RPrim_tanh
+    //| RPrim_pown
+    | RPrim_pow
     | RMethod of System.Reflection.MemberInfo
     | UMethod of (DMemberDef * Value)
 
@@ -95,6 +117,8 @@ let getFields obj =
 let (|Value|) (v: Value) = v.Value
 
 let Value (v: obj) = { Value = v }
+
+let fail x y= failwith "invalid op"
 
 let getVal (Value v) = v
 
@@ -164,10 +188,21 @@ let protectInvoke f =
 let EvalTraitCallInvoke (traitName, sourceTypeR: Type, isInstance, argExprsV: obj[]) =
     let objV = if isInstance then argExprsV.[0] else null
     let argsV = if isInstance then argExprsV.[1..] else argExprsV
-    let bindingFlags = (if isInstance then BindingFlags.Instance else BindingFlags.Static) ||| BindingFlags.Public ||| BindingFlags.NonPublic ||| BindingFlags.InvokeMethod
+    let bindingFlags =
+        (if isInstance then BindingFlags.Instance else BindingFlags.Static) 
+        ||| BindingFlags.Public 
+        ||| BindingFlags.NonPublic 
+        ||| BindingFlags.InvokeMethod
+        ||| BindingFlags.FlattenHierarchy
     //printfn "sourceTypeR = %A, traitName = %s, objV = %A, argsV types = %A" sourceTypeR traitName objV [| for a in argsV -> a.GetType() |]
     let resObj = try protectInvoke (fun () ->  sourceTypeR.InvokeMember(traitName, bindingFlags, null, objV, argsV)) with e -> printfn "failed!"; reraise ()
     Value resObj
+
+let inline unOp op (argsV: obj[]) f32 f64 = 
+    match argsV.[0] with 
+    | (:? double as v1) -> Value (box (f64 v1))
+    | (:? single as v1) -> Value (box (f32 v1))
+    | _ -> EvalTraitCallInvoke(op, argsV.[0].GetType(), false, argsV)
 
 let inline binOp op (argsV: obj[]) i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 d = 
     match argsV.[0] with 
@@ -263,8 +298,8 @@ type EvalContext (assemblyName: AssemblyName, ?dyntypes: bool, ?assemblyResolver
     let methodThunks = ConcurrentDictionary<(ResolvedEntity * string * ResolvedTypes),(DMemberDef * Value)>(HashIdentity.Structural)
     
     // For emitting shell types
-    let mutable shellTypeMemberCount = 0
-    let shellTypeThunks = ConcurrentDictionary<int,(DMemberDef * MethodLambdaValue)>(HashIdentity.Structural)
+    let mutable shellTypeThunkCount = 0
+    let shellTypeThunks = ConcurrentDictionary<int, MethodLambdaValue>(HashIdentity.Structural)
 
     // TODO: add these resolution tables
     //let unionCaseResolutions = ConcurrentDictionary<(DType * DUnionCaseRef),ResolvedUnionCase>(HashIdentity.Structural)
@@ -313,30 +348,28 @@ type EvalContext (assemblyName: AssemblyName, ?dyntypes: bool, ?assemblyResolver
     let op_checked_char = methinfoof <@ Operators.Checked.char @> 
     let op_checked_minus = methinfoof <@ Operators.Checked.(-) @> 
     let op_checked_mul = methinfoof <@ Operators.Checked.(*) @> 
-(*
- TODO:
-            let inline absImpl (x: ^T) : ^T = 
-            let inline  acosImpl(x: ^T) : ^T = 
-            let inline  asinImpl(x: ^T) : ^T = 
-            let inline  atanImpl(x: ^T) : ^T = 
-            let inline  atan2Impl(x: ^T) (y: ^T) : 'U = 
-            let inline  ceilImpl(x: ^T) : ^T = 
-            let inline  expImpl(x: ^T) : ^T = 
-            let inline floorImpl (x: ^T) : ^T = 
-            let inline truncateImpl (x: ^T) : ^T = 
-            let inline roundImpl (x: ^T) : ^T = 
-            let inline signImpl (x: ^T) : int = 
-            let inline  logImpl(x: ^T) : ^T = 
-            let inline  log10Impl(x: ^T) : ^T = 
-            let inline  sqrtImpl(x: ^T) : ^U = 
-            let inline  cosImpl(x: ^T) : ^T = 
-            let inline  coshImpl(x: ^T) : ^T = 
-            let inline  sinImpl(x: ^T) : ^T = 
-            let inline  sinhImpl(x: ^T) : ^T = 
-            let inline  tanImpl(x: ^T) : ^T = 
-            let inline  tanhImpl(x: ^T) : ^T = 
-            let inline  powImpl (x: ^T) (y: ^U) : ^T = 
-*)
+    let op_abs = methinfoof <@ Operators.abs @> 
+    let op_acos = methinfoof <@ Operators.acos @> 
+    let op_asin = methinfoof <@ Operators.asin @> 
+    let op_atan = methinfoof <@ Operators.atan @> 
+    let op_atan2 = methinfoof <@ Operators.atan2 @> 
+    let op_ceil = methinfoof <@ Operators.ceil @> 
+    let op_exp = methinfoof <@ Operators.exp @> 
+    let op_floor = methinfoof <@ Operators.floor @> 
+    let op_truncate = methinfoof <@ Operators.truncate @> 
+    let op_round = methinfoof <@ Operators.round @> 
+    let op_sign = methinfoof <@ Operators.sign @> 
+    let op_log = methinfoof <@ Operators.log @> 
+    let op_log10 = methinfoof <@ Operators.log10 @> 
+    let op_sqrt = methinfoof <@ Operators.sqrt @> 
+    let op_cos = methinfoof <@ Operators.cos @> 
+    let op_cosh = methinfoof <@ Operators.cosh @> 
+    let op_sin = methinfoof <@ Operators.sin @> 
+    let op_sinh = methinfoof <@ Operators.sinh @> 
+    let op_tan = methinfoof <@ Operators.tan @> 
+    let op_tanh = methinfoof <@ Operators.tanh @> 
+    //let op_pown = methinfoof <@ Operators.pown @> 
+    let op_pow = methinfoof <@ Operators.( ** ) @> 
 
     /// Resolve an F# entity (type or module)
     let resolveEntity entityRef = 
@@ -551,6 +584,27 @@ type EvalContext (assemblyName: AssemblyName, ?dyntypes: bool, ?assemblyResolver
         elif m = op_checked_char then RPrim_checked_char
         elif m = op_checked_minus then RPrim_checked_minus
         elif m = op_checked_mul then RPrim_checked_mul
+        elif m = op_abs then RPrim_abs
+        elif m = op_acos then RPrim_acos
+        elif m = op_asin then RPrim_asin
+        elif m = op_atan then RPrim_atan
+        elif m = op_atan2 then RPrim_atan2
+        elif m = op_ceil then RPrim_ceil
+        elif m = op_exp then RPrim_exp
+        elif m = op_floor then RPrim_floor
+        elif m = op_truncate then RPrim_truncate
+        elif m = op_round then RPrim_round
+        elif m = op_sign then RPrim_sign
+        elif m = op_log then RPrim_log
+        elif m = op_log10 then RPrim_log10
+        elif m = op_sqrt then RPrim_sqrt
+        elif m = op_cos then RPrim_cos
+        elif m = op_cosh then RPrim_cosh
+        elif m = op_sin then RPrim_sin
+        elif m = op_sinh then RPrim_sinh
+        elif m = op_tan then RPrim_tan
+        elif m = op_tanh then RPrim_tanh
+        elif m = op_pow then RPrim_pow
         else RMethod m
 
     /// Get the lambda value for the method
@@ -612,24 +666,38 @@ type EvalContext (assemblyName: AssemblyName, ?dyntypes: bool, ?assemblyResolver
             minfo.MakeGenericMethod(typeArgs2V) 
         else minfo
 
-    let instantiateConstructor env (cinfo: ConstructorInfo) typeArgs = 
+    let rec instantiateType (typeArgs: Type[]) (ty: Type) = 
+        if ty.IsGenericType then 
+            ty.MakeGenericType(Array.map (instantiateType typeArgs) (ty.GetGenericArguments()))
+        elif ty.IsArray then
+            (instantiateType typeArgs (ty.GetElementType())).MakeArrayType(ty.GetArrayRank())
+        elif ty.IsByRef then
+            (instantiateType typeArgs (ty.GetElementType())).MakeByRefType()
+        elif ty.IsPointer then
+            (instantiateType typeArgs (ty.GetElementType())).MakePointerType()
+        elif ty.IsGenericParameter then
+            typeArgs.[ty.GenericParameterPosition]
+        else 
+            ty
+
+    let instantiateConstructor typeArgsT (cinfo: ConstructorInfo) = 
         if cinfo.DeclaringType.IsGenericType then 
-            let (RTypesErased env bctorTypeArgsT) = resolveTypes(env, typeArgs) 
-            let tinfo = cinfo.DeclaringType.MakeGenericType(bctorTypeArgsT)
+            let tinfo = cinfo.DeclaringType.MakeGenericType(typeArgsT)
             tinfo.GetConstructors(bindAll) |> Array.find (fun cinfo2 -> cinfo2.MetadataToken = cinfo.MetadataToken)
         else cinfo
 
-    member ctxt.EvalShellMethodBody(memberId: int, typeArgsV: Type[], argsV: obj[]) : obj = 
-        let membDef, fM = shellTypeThunks.[memberId] 
+    member ctxt.InterpretExpressionThunk(thunkId: int, typeArgsV: Type[], argsV: obj[]) : obj = 
+        let fM = shellTypeThunks.[thunkId] 
         //if membDef.Name <> "ToString" then 
-        //   printfn "EvalShellMethodBody: memberId = %d, typeArgsV=%A, args = %A" memberId typeArgsV argsV
+        //   printfn "InterpretExpressionThunk: memberId = %d, typeArgsV=%A, args = %A" memberId typeArgsV argsV
         let (MethodLambdaValue f) = fM
         let res = f (typeArgsV, argsV) 
         //if membDef.Name <> "ToString" then 
-        //   printfn "EvalShellMethodBody:res = %A" res
+        //   printfn "InterpretExpressionThunk:res = %A" res
         //if membDef.Name <> "ToString" then 
         //    sink.CallAndReturn(None (* no caller references available for these invokes *), Choice2Of2 membDef, typeArgsV, argsV, Value res)
         res
+
 
     /// Dynamically emit "shell" .NET type definitions for types with include thunks for any
     /// virtual methods and interface implementations, and constructors to actually make an object of the
@@ -638,7 +706,7 @@ type EvalContext (assemblyName: AssemblyName, ?dyntypes: bool, ?assemblyResolver
         let asmB = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run)
         let modB = asmB.DefineDynamicModule ("Module")
 
-        let shellTypeBuilders = Dictionary<DMemberRef,(ConstructorBuilder * Type[])>(HashIdentity.Structural)
+        let shellTypeConstructorBuilders = Dictionary<DMemberRef,(ConstructorBuilder * Type[])>(HashIdentity.Structural)
         let shellTypeMethodBuilders = Dictionary<DMemberRef,(MethodBuilder * Type[] * Type)>(HashIdentity.Structural)
         let shellTypeEntityInfo = Dictionary<DEntityRef,DEntityDef>(HashIdentity.Structural)
 
@@ -648,6 +716,9 @@ type EvalContext (assemblyName: AssemblyName, ?dyntypes: bool, ?assemblyResolver
         let ctxtTypeInfo = ctxtTypB.CreateTypeInfo()
         ctxtTypeInfo.GetField("$ctxt").SetValue(null, ctxt)
 
+        // TODO: emitting shell types for union and record types requires us to add all the
+        // attributes generated by the F# compiler for those kinds of types.
+        // These are not reported to us by FCS
         let canEmitShellType (entityDef: DEntityDef) =
             not (entityDef.IsInterface || entityDef.IsUnion || entityDef.IsRecord || entityDef.IsStruct)
 
@@ -701,23 +772,6 @@ type EvalContext (assemblyName: AssemblyName, ?dyntypes: bool, ?assemblyResolver
                         let (RTypeErased env t) = resolveType (env, i) 
                         typB.AddInterfaceImplementation(t)
 
-                        // TODO: Union and Record have IStructuralEquatble etc. implementations
-                        // but FCS is not reporting these in the available bindings
-                        //if not ((entityDef.IsUnion || entityDef.IsRecord) &&
-                        //        (t.FullName.StartsWith("System.IEquatable`1[") ||
-                        //         t.FullName = "System.Collections.IStructuralEquatable" ||
-                        //         t.FullName.StartsWith("System.IComparable`1[") ||
-                        //         t.FullName.StartsWith("System.IComparable") ||
-                        //         t.FullName.StartsWith("System.Collections.IStructuralComparable"))) then
-                    //// Add the attributes generated by the F# compiler
-                    //if entityDef.IsUnion then
-                    //    let c = typeof<CompilationMappingAttribute>.GetConstructor([| typeof<SourceConstructFlags> |])
-                    //    let cattr = CustomAttributeBuilder(c, [| SourceConstructFlags.SumType|])
-                    //    typB.SetCustomAttribute(cattr)
-                    //if entityDef.IsRecord then
-                    //    let c = typeof<CompilationMappingAttribute>.GetConstructor([| typeof<SourceConstructFlags> |])
-                    //    let cattr = CustomAttributeBuilder(c, [| SourceConstructFlags.RecordType|])
-                    //    typB.SetCustomAttribute(cattr)
                     phase2(subDecls)
                 | _ -> ()
         phase2(decls)
@@ -762,8 +816,8 @@ type EvalContext (assemblyName: AssemblyName, ?dyntypes: bool, ?assemblyResolver
                         // TODO : base ctor calls must currently take no arguments (since we
                         // don't have an expression compiler - we could interpret these)
                         let attrs = MethodAttributes.Public 
-                        let mB = typB.DefineConstructor(attrs, CallingConventions.Standard,paramTypesT)
-                        shellTypeBuilders.[membRef] <- (mB, paramTypesT)
+                        let cB = typB.DefineConstructor(attrs, CallingConventions.Standard,paramTypesT)
+                        shellTypeConstructorBuilders.[membRef] <- (cB, paramTypesT)
                     elif membDef.ImplementedSlots.Length > 0 then
 
                         let cconv = CallingConventions.HasThis
@@ -797,6 +851,55 @@ type EvalContext (assemblyName: AssemblyName, ?dyntypes: bool, ?assemblyResolver
                 | _ -> ()
         phase3(decls)
 
+        let EmitInterpretExpression(ilg: ILGenerator, gps: DGenericParameterDef[], gpTys: Type[], isCaptureThis, isInstanceCtxt, ps: DLocalDef[], paramTypesT: Type[], thisTypeB: Type, exprT: Type, body: DExpr) = 
+            shellTypeThunkCount <- shellTypeThunkCount + 1
+            let thunkId = shellTypeThunkCount
+            ilg.Emit(OpCodes.Ldsfld, ctxtFld)
+            ilg.Emit(OpCodes.Ldc_I4, thunkId)
+
+            // Create the array of type arguments 
+            ilg.Emit(OpCodes.Ldc_I4, gps.Length)
+            ilg.Emit(OpCodes.Newarr, typeof<obj>)
+            for i in 0 .. gpTys.Length - 1 do
+                ilg.Emit(OpCodes.Dup)
+                ilg.Emit(OpCodes.Ldc_I4, i)
+                ilg.Emit(OpCodes.Ldtoken,gpTys.[i])
+                let meth = typeof<System.Type>.GetMethod("GetTypeFromHandle")
+                ilg.Emit(OpCodes.Call, meth)
+                ilg.Emit(OpCodes.Stelem_Ref)
+
+            // Create the array of 'this' plus arguments 
+            let argAdjust = (if isInstanceCtxt then 1 else 0)
+            let arrAdjust = (if isCaptureThis then 1 else 0)
+            ilg.Emit(OpCodes.Ldc_I4, paramTypesT.Length+arrAdjust)
+            ilg.Emit(OpCodes.Newarr, typeof<obj>)
+            
+            // Capture the this
+            if isCaptureThis then 
+                ilg.Emit(OpCodes.Dup)
+                ilg.Emit(OpCodes.Ldc_I4, 0)
+                ilg.Emit(OpCodes.Ldarg, 0)
+                if thisTypeB.IsValueType then
+                    ilg.Emit(OpCodes.Box, thisTypeB)
+                ilg.Emit(OpCodes.Stelem_Ref)
+            for i in 0 .. paramTypesT.Length  - 1 do
+                ilg.Emit(OpCodes.Dup)
+                ilg.Emit(OpCodes.Ldc_I4, i+arrAdjust)
+                ilg.Emit(OpCodes.Ldarg, i+argAdjust)
+                if paramTypesT.[i].IsValueType then
+                    ilg.Emit(OpCodes.Box, paramTypesT.[i])
+                ilg.Emit(OpCodes.Stelem_Ref)
+
+            // call the interpreter
+            ilg.Emit(OpCodes.Call, typeof<EvalContext>.GetMethod("InterpretExpressionThunk"))
+            if exprT = typeof<Void> then
+                ilg.Emit(OpCodes.Pop)
+            elif exprT.IsValueType then
+                ilg.Emit(OpCodes.Unbox_Any, exprT)
+                        
+            let thunk = ctxt.EvalMethodLambda (envEmpty, false, isCaptureThis, gps, ps, body)
+            shellTypeThunks.[thunkId] <- thunk
+
         /// Fill in the body of the constructors and virtual/interface method stubs
         let rec phase4(decls: DDecl[]) = 
             for decl in decls do
@@ -808,138 +911,58 @@ type EvalContext (assemblyName: AssemblyName, ?dyntypes: bool, ?assemblyResolver
                     let entityDef = shellTypeEntityInfo.[membDef.EnclosingEntity]
                     let typB, env  = enterTypeDef entityDef
                     if membDef.Name = ".ctor" then
-                        let mB, paramTypesT = shellTypeBuilders.[membRef]
+                        let mB, paramTypesT = shellTypeConstructorBuilders.[membRef]
+                        let gpTys = typB.GetGenericArguments()
                         
                         // Strip off the call to the base class constructor and emit it in compiled code
-                        // since we can't interpret that
-                        //
-                        // TODO : base ctor calls must currently take no arguments (since we
-                        // don't have an expression compiler - we could interpret these)
                         let ilg = mB.GetILGenerator()
-                        shellTypeMemberCount <- shellTypeMemberCount + 1
-                        let memberId = shellTypeMemberCount
 
                         // Check if this ctor has a base class constructor or self constructor
-                        let bctor, bctorTypeArgs, initCode = 
+                        let baseCtor, baseCtorTypeArgs, baseCtorArgs, initCode = 
                             match body with
                             // base calls without arguments
-                            | DExpr.Sequential(DExpr.Call(None, bctor, bctorTypeArgs, [| |], [| |], _), initCode) -> 
-                                 bctor, bctorTypeArgs, initCode
-                            | DExpr.Sequential(DExpr.NewObject(bctor, bctorTypeArgs, [| |], _), initCode) -> 
-                                 bctor, bctorTypeArgs, initCode
-                            // base calls with arguments
-                            | DExpr.Sequential(DExpr.Call(None, bctor, bctorTypeArgs, [| |], _, _), rest) -> 
-                                 failwith "TODO: calls to base class constructors taking arguments"
+                            | DExpr.Sequential(DExpr.Call(None, baseCtor, baseCtorTypeArgs, [| |], baseCtorArgs, _), initCode) -> 
+                                 baseCtor, baseCtorTypeArgs, baseCtorArgs, initCode
+                            | DExpr.Sequential(DExpr.NewObject(baseCtor, baseCtorTypeArgs, baseCtorArgs, _), initCode) -> 
+                                 baseCtor, baseCtorTypeArgs, baseCtorArgs, initCode
                             // self-init calls
-                            | DExpr.Call(None, bctor, bctorTypeArgs, [| |], args, _) -> 
-                                 bctor, bctorTypeArgs, body
+                            | DExpr.Call(None, baseCtor, baseCtorTypeArgs, [| |], baseCtorArgs, _) -> 
+                                 baseCtor, baseCtorTypeArgs, baseCtorArgs, body
                             | _ -> 
                                 failwithf "TODO: unknown constructor body %A" body
 
-                        let bcinfo = 
-                            match shellTypeBuilders.TryGetValue(bctor) with 
-                            | true, (v, _) -> (v :> ConstructorInfo)
+                        let baseCtorInfo, baseCtorParamTypes = 
+                            match shellTypeConstructorBuilders.TryGetValue(baseCtor) with 
+                            | true, (v, baseCtorParamTypes) -> 
+                                ((v :> ConstructorInfo), baseCtorParamTypes)
                             | _ -> 
-                            match resolveMethod bctor with
-                            | RMethod (:? ConstructorInfo as bcinfo) -> bcinfo
+                            match resolveMethod baseCtor with
+                            | RMethod (:? ConstructorInfo as baseCtorInfo) -> 
+                                baseCtorInfo, (baseCtorInfo.GetParameters() |> Array.map (fun p -> p.ParameterType))
                             | _ -> failwith "unexpected: couldn't resolve ctor"
-                        let ibcinfo = instantiateConstructor env bcinfo bctorTypeArgs
+                        let (RTypesErased env baseCtorTypeArgsT) = resolveTypes(env, baseCtorTypeArgs) 
+                        let ibaseCtorInfo = instantiateConstructor baseCtorTypeArgsT baseCtorInfo
+                        let ibaseCtorParamTypes = baseCtorParamTypes |> Array.map (instantiateType baseCtorTypeArgsT)
+
                         ilg.Emit(OpCodes.Ldarg, 0)
-                        ilg.Emit(OpCodes.Call, ibcinfo)
-                        // TODO: for inheritance from interpreted types we should first
-                        // call init code thunks for the base ctor
-                        ilg.Emit(OpCodes.Ldsfld, ctxtFld)
-                        ilg.Emit(OpCodes.Ldc_I4, memberId)
+                        // The arguments to the constructor are evaluated in the interpreter
+                        for (baseCtorArg, baseCtorParamType) in Array.zip baseCtorArgs ibaseCtorParamTypes do
+                            EmitInterpretExpression(ilg, [| |], gpTys, false, true, membDef.Parameters, paramTypesT, typB, baseCtorParamType, baseCtorArg)
 
-                        // Create the array of type arguments 
-                        let gps = typB.GetGenericArguments()
-                        ilg.Emit(OpCodes.Ldc_I4, gps.Length)
-                        ilg.Emit(OpCodes.Newarr, typeof<obj>)
-                        for i in 0 .. gps.Length - 1 do
-                            ilg.Emit(OpCodes.Dup)
-                            ilg.Emit(OpCodes.Ldc_I4, i)
-                            ilg.Emit(OpCodes.Ldtoken,gps.[i])
-                            let meth = typeof<System.Type>.GetMethod("GetTypeFromHandle")
-                            ilg.Emit(OpCodes.Call, meth)
-                            ilg.Emit(OpCodes.Stelem_Ref)
+                        ilg.Emit(OpCodes.Call, ibaseCtorInfo)
 
-                        // Create the array of 'this' plus arguments 
-                        let adjust = 1
-                        ilg.Emit(OpCodes.Ldc_I4, paramTypesT.Length+adjust)
-                        ilg.Emit(OpCodes.Newarr, typeof<obj>)
-                        
-                        ilg.Emit(OpCodes.Dup)
-                        ilg.Emit(OpCodes.Ldc_I4, 0)
-                        ilg.Emit(OpCodes.Ldarg, 0)
-                        if typB.IsValueType then
-                            ilg.Emit(OpCodes.Box, typB)
-                        ilg.Emit(OpCodes.Stelem_Ref)
-                        for i in 0 .. paramTypesT.Length  - 1 do
-                            ilg.Emit(OpCodes.Dup)
-                            ilg.Emit(OpCodes.Ldc_I4, i+adjust)
-                            ilg.Emit(OpCodes.Ldarg, i+adjust)
-                            if paramTypesT.[i].IsValueType then
-                                ilg.Emit(OpCodes.Box, paramTypesT.[i])
-                            ilg.Emit(OpCodes.Stelem_Ref)
+                        EmitInterpretExpression(ilg, [| |], gpTys, true, true, membDef.Parameters, paramTypesT, typB, typeof<Void>, initCode)
 
-                        // call the initCode
-                        ilg.Emit(OpCodes.Call, typeof<EvalContext>.GetMethod("EvalShellMethodBody"))
-                        ilg.Emit(OpCodes.Pop)
                         ilg.Emit(OpCodes.Ret)
 
-                        // For primary constructors the thunk holds the remainder of
-                        // the initialization code
-
-                        let thunk = ctxt.EvalMethodLambda (envEmpty, false, true, membDef.GenericParameters, membDef.Parameters, initCode)
-                        shellTypeThunks.[memberId] <- (membDef, thunk)
                     elif membDef.ImplementedSlots.Length > 0 then
                         let mB, paramTypesT, returnTypeT = shellTypeMethodBuilders.[membRef]
-
+                        let gpTys = Array.append (typB.GetGenericArguments()) (mB.GetGenericArguments())
                         let ilg = mB.GetILGenerator()
-                        shellTypeMemberCount <- shellTypeMemberCount + 1
-                        let memberId = shellTypeMemberCount
-                        ilg.Emit(OpCodes.Ldsfld, ctxtFld)
-                        ilg.Emit(OpCodes.Ldc_I4, memberId)
-
-                        // Create the array of type arguments 
-                        let gps = Array.append (typB.GetGenericArguments()) (mB.GetGenericArguments())
-                        ilg.Emit(OpCodes.Ldc_I4, gps.Length)
-                        ilg.Emit(OpCodes.Newarr, typeof<obj>)
-                        for i in 0 .. gps.Length - 1 do
-                            ilg.Emit(OpCodes.Dup)
-                            ilg.Emit(OpCodes.Ldc_I4, i)
-                            ilg.Emit(OpCodes.Ldtoken,gps.[i])
-                            let meth = typeof<System.Type>.GetMethod("GetTypeFromHandle")
-                            ilg.Emit(OpCodes.Call, meth)
-                            ilg.Emit(OpCodes.Stelem_Ref)
-
-                        // Create the array of 'this' plus arguments 
-                        let adjust = (if membDef.IsInstance then 1 else 0)
-                        ilg.Emit(OpCodes.Ldc_I4, paramTypesT.Length+adjust)
-                        ilg.Emit(OpCodes.Newarr, typeof<obj>)
-                        if adjust = 1 then 
-                            ilg.Emit(OpCodes.Dup)
-                            ilg.Emit(OpCodes.Ldc_I4, 0)
-                            ilg.Emit(OpCodes.Ldarg, 0)
-                            if typB.IsValueType then
-                                ilg.Emit(OpCodes.Box, typB)
-                            ilg.Emit(OpCodes.Stelem_Ref)
-                        for i in 0 .. paramTypesT.Length  - 1 do
-                            ilg.Emit(OpCodes.Dup)
-                            ilg.Emit(OpCodes.Ldc_I4, i+adjust)
-                            ilg.Emit(OpCodes.Ldarg, i+adjust)
-                            if paramTypesT.[i].IsValueType then
-                                ilg.Emit(OpCodes.Box, paramTypesT.[i])
-                            ilg.Emit(OpCodes.Stelem_Ref)
-
-                        // call the method
-                        ilg.Emit(OpCodes.Call, typeof<EvalContext>.GetMethod("EvalShellMethodBody"))
-                        if returnTypeT = typeof<Void> then
-                            ilg.Emit(OpCodes.Pop)
-                        elif returnTypeT.IsValueType then
-                            ilg.Emit(OpCodes.Unbox_Any, returnTypeT)
+                        EmitInterpretExpression(ilg, membDef.GenericParameters, gpTys, membDef.IsInstance, membDef.IsInstance, membDef.Parameters, paramTypesT, typB, returnTypeT, body)
                         ilg.Emit(OpCodes.Ret)
                         
+                        // Emit the method overrides
                         for slot in membDef.ImplementedSlots do
                             let slotR = 
                                 match resolveMethod slot.Member with 
@@ -954,8 +977,6 @@ type EvalContext (assemblyName: AssemblyName, ?dyntypes: bool, ?assemblyResolver
                                 //printfn "\nslotV2 = %A, (slotV = slotV2) = %b\n\n" slotV2 (slotV = slotV2)
                                 typB.DefineMethodOverride(mB, slotV)
 
-                        let thunk = ctxt.EvalMethodLambda (envEmpty, false, membDef.IsInstance, membDef.GenericParameters, membDef.Parameters, body)
-                        shellTypeThunks.[memberId] <- (membDef, thunk)
                 | _ -> ()
         phase4(decls)
         let rec phaseFinal(decls) =
@@ -1285,7 +1306,8 @@ type EvalContext (assemblyName: AssemblyName, ?dyntypes: bool, ?assemblyResolver
 
         match methR, typeArgsR with 
         | RMethod (:? ConstructorInfo as cinfo), RTypesErased env typeArgsV -> 
-            let icinfo = instantiateConstructor env cinfo typeArgs
+            let (RTypesErased env typeArgsT) = resolveTypes(env, typeArgs) 
+            let icinfo = instantiateConstructor typeArgsT cinfo
             protectInvoke (fun () -> icinfo.Invoke(argsV)) |> Value
 
         | UMethod (membDef, Value (:? MethodLambdaValue as fM )), RTypesErased env typeArgsV -> 
@@ -1389,6 +1411,28 @@ type EvalContext (assemblyName: AssemblyName, ?dyntypes: bool, ?assemblyResolver
         | RPrim_checked_char -> Value (Convert.ToChar argsV.[0])
         | RPrim_checked_minus -> binOp "op_Subtraction" argsV Checked.(-) Checked.(-) Checked.(-) Checked.(-) Checked.(-) Checked.(-) Checked.(-) Checked.(-) Checked.(-) Checked.(-) Checked.(-)
         | RPrim_checked_mul -> binOp "op_Multiply" argsV Checked.(*) Checked.(*) Checked.(*) Checked.(*) Checked.(*) Checked.(*) Checked.(*) Checked.(*) Checked.(*) Checked.(*) Checked.(*)
+        | RPrim_abs -> unOp "Abs" argsV abs abs
+        | RPrim_acos -> unOp "Acos" argsV acos acos
+        | RPrim_asin -> unOp "Asin" argsV asin asin
+        | RPrim_atan -> unOp "Atan" argsV atan atan
+        | RPrim_atan2 -> binOp "Atan2" argsV fail fail fail fail fail fail fail fail atan2 atan2 fail
+        | RPrim_ceil -> unOp "Ceil" argsV ceil ceil
+        | RPrim_exp -> unOp "Exp" argsV exp exp
+        | RPrim_floor -> unOp "Floor" argsV floor floor
+        | RPrim_truncate -> unOp "Truncate" argsV truncate truncate
+        | RPrim_round -> unOp "Round" argsV round round
+        | RPrim_sign -> unOp "Sign" argsV sign sign
+        | RPrim_log -> unOp "Log" argsV log log
+        | RPrim_log10 -> unOp "Log10" argsV log10 log10
+        | RPrim_sqrt -> unOp "Sqrt" argsV sqrt sqrt
+        | RPrim_cos -> unOp "Cos" argsV cos cos
+        | RPrim_cosh -> unOp "Cosh" argsV cosh cosh
+        | RPrim_sin -> unOp "Sin" argsV sin sin
+        | RPrim_sinh -> unOp "Sinh" argsV sinh sinh
+        | RPrim_tan -> unOp "Tan" argsV tan tan
+        | RPrim_tanh -> unOp "Tanh" argsV tanh tanh
+        //| RPrim_pown -> unOp "Pown" argsV pown pown
+        | RPrim_pow -> binOp "Pow" argsV fail fail fail fail fail fail fail fail ( ** ) ( ** ) fail
         | _ ->
 
         let typeArgs1R = resolveTypes (env, typeArgs1)

--- a/src/ProcessCommandLine.fs
+++ b/src/ProcessCommandLine.fs
@@ -305,7 +305,7 @@ let ProcessCommandLine (argv: string[]) =
                  + " |]"
             elif ty.GetArrayRank() = 2 then 
                 "[| " + 
-                    String.concat ";   \n " 
+                    String.concat ";   \n" 
                        [ for i in 0 .. min (LISTLIM/2) (value.GetLength(0) - 1) -> 
                             String.concat ";" 
                                [ for j in 0 .. min (LISTLIM/2) (value.GetLength(1) - 1) -> 
@@ -366,24 +366,24 @@ let ProcessCommandLine (argv: string[]) =
                             [ for (action, value) in lines do 
                                   let action = (if action = "" then "" else action + " ")
                                   let valueText = formatValue value
-                                  let valueText = valueText.Replace("\n", " ").Replace("\r", " ").Replace("\t", " ")
+                                  let valueText = valueText.Replace("\n", "\\n").Replace("\r", "").Replace("\t", " ")
                                   let valueText = 
                                       if valueText.Length > MAXTOOLTIP then 
                                           valueText.[0 .. MAXTOOLTIP-1] + "..."
                                       else   
                                           valueText
                                   yield action + valueText ]
-                            |> String.concat "~   " // special new-line character known by experimental VS tooling + indent
+                            |> String.concat "\\n  " // special new-line character known by experimental VS tooling + indent
                     
-                        let sep = (if lines.Length = 1 then " " else "~   ")
+                        let sep = (if lines.Length = 1 then " " else "\\n")
                         let line = sprintf "ToolTip\t%d\t%d\t%d\t%d\tLiveCheck:%s%s" range.StartLine range.StartColumn range.EndLine range.EndColumn sep valuesText
                         yield line
 
                for (exn:exn, rangeStack) in errors do 
                     if List.length rangeStack > 0 then 
                         let range = List.last rangeStack 
-                        let message = "LiveCheck failed: " + exn.Message.Replace("\t"," ").Replace("\r","   ").Replace("\n","   ") 
-                        printfn "%s" message
+                        printfn "%s" exn.Message
+                        let message = "LiveCheck failed: " + exn.Message.Replace("\t"," ").Replace("\r","   ").Replace("\n","\\n") 
                         let line = sprintf "Error\t%d\t%d\t%d\t%d\terror\t%s\t304" range.StartLine range.StartColumn range.EndLine range.EndColumn message
                         yield line |]
 

--- a/src/ProcessCommandLine.fs
+++ b/src/ProcessCommandLine.fs
@@ -249,7 +249,7 @@ let ProcessCommandLine (argv: string[]) =
         if not (Directory.Exists infoDir) then
            Directory.CreateDirectory infoDir |> ignore
         try 
-            File.WriteAllLines(infoFile, lines)
+            File.WriteAllLines(infoFile, lines, encoding=Encoding.Unicode)
         finally
             try if Directory.Exists infoDir && File.Exists lockFile then File.Delete lockFile with _ -> ()
 
@@ -334,7 +334,7 @@ let ProcessCommandLine (argv: string[]) =
     /// Write an info file containing extra information to make available to F# tooling.
     /// This is currently experimental and only experimental additions to F# tooling
     /// watch and consume this information.
-    let writeInfoFile (tooltips: (DRange * (string * obj) list * bool)[]) sourceFile errors = 
+    let writeInfoFile (tooltips: (DRange * (string * obj) list * bool)[]) sourceFile (diags: DDiagnostic[]) = 
 
         let lines = 
             let ranges =  HashSet<DRange>(HashIdentity.Structural)
@@ -379,12 +379,13 @@ let ProcessCommandLine (argv: string[]) =
                         let line = sprintf "ToolTip\t%d\t%d\t%d\t%d\tLiveCheck:%s%s" range.StartLine range.StartColumn range.EndLine range.EndColumn sep valuesText
                         yield line
 
-               for (exn:exn, rangeStack) in errors do 
-                    if List.length rangeStack > 0 then 
-                        let range = List.last rangeStack 
-                        printfn "%s" exn.Message
-                        let message = "LiveCheck failed: " + exn.Message.Replace("\t"," ").Replace("\r","   ").Replace("\n","\\n") 
-                        let line = sprintf "Error\t%d\t%d\t%d\t%d\terror\t%s\t304" range.StartLine range.StartColumn range.EndLine range.EndColumn message
+               for diag in diags do 
+                    printfn "%s" (diag.ToString())
+                    if List.length diag.Stack > 0 then 
+                        let range = List.last diag.Stack
+                        let message = "LiveCheck failed: " + diag.Message.Replace("\t"," ").Replace("\r","   ").Replace("\n","\\n") 
+                        let sev = match diag.Severity with 0 | 1 -> "warning" | _ -> "error"
+                        let line = sprintf "Error\t%d\t%d\t%d\t%d\t%s\t%s\t%d" range.StartLine range.StartColumn range.EndLine range.EndColumn sev message diag.Number
                         yield line |]
 
         emitInfoFile sourceFile lines
@@ -450,7 +451,8 @@ let ProcessCommandLine (argv: string[]) =
                              vdef.Range |> Option.iter (fun r -> tooltips.Add ((r, [("", value.Value)], false)))
 
                      member __.UseLocal(vref, value) = 
-                         vref.Range |> Option.iter (fun r -> tooltips.Add ((r, [("", value.Value)], false)))
+                         if not vref.IsCompilerGenerated then 
+                             vref.Range |> Option.iter (fun r -> tooltips.Add ((r, [("", value.Value)], false)))
                 }
                 |> Some
             else  
@@ -466,17 +468,13 @@ let ProcessCommandLine (argv: string[]) =
 
         for (sourceFile, ds) in fileConvContents do 
             printfn "evaluating decls.... " 
-            let errors = ctxt.TryEvalDecls (envEmpty, ds.Code, evalLiveChecksOnly=livecheck)
+            let diags = ctxt.TryEvalDecls (envEmpty, ds.Code, evalLiveChecksOnly=livecheck)
 
             if writeinfo then 
-                writeInfoFile (tooltips.ToArray()) sourceFile errors
-            for (exn, locs) in errors do
-                if watch then
-                    printfn "fslive: exception: %A" (exn.ToString())
-                    for loc in locs do 
-                        printfn "   --> %O" loc
-                else
-                    raise exn
+                writeInfoFile (tooltips.ToArray()) sourceFile diags
+            for diag in diags do
+                printfn "%s" (diag.ToString())
+            if not watch && diags |> Array.exists (fun diag -> diag.Severity >= 2) then exit 1
 
             printfn "...evaluated decls" 
 

--- a/src/ProcessCommandLine.fs
+++ b/src/ProcessCommandLine.fs
@@ -365,8 +365,8 @@ let ProcessCommandLine (argv: string[]) =
                         let valuesText = 
                             [ for (action, value) in lines do 
                                   let action = (if action = "" then "" else action + " ")
-                                  let valueText = formatValue value
-                                  let valueText = valueText.Replace("\n", "\\n").Replace("\r", "").Replace("\t", " ")
+                                  let valueText = try formatValue value with e -> sprintf "??? (%s)" e.Message
+                                  let valueText = valueText.Replace("\n", "\\n").Replace("\r", "").Replace("\t", "")
                                   let valueText = 
                                       if valueText.Length > MAXTOOLTIP then 
                                           valueText.[0 .. MAXTOOLTIP-1] + "..."

--- a/tests/PortaCodeTests.fs
+++ b/tests/PortaCodeTests.fs
@@ -235,7 +235,13 @@ module SmokeTestLiveCheck =
 
         // 'v' has been incremented - because `x1` is now evaluated!
         if v <> 2 then failwithf "no way Julie, v = %d" v
-        if y2 <> 5 then failwithf "no way Jose, x2 = %d, v = %d" x2 v
+        if y2 <> 5 then failwithf "no way Jose, y2 = %d, v = %d" y2 v
+
+        let y3 = x1 + 1
+
+        // 'v' is not incremented again - because `x1` is already evaluated!
+        if v <> 2 then failwithf "no way Julie, v = %d" v
+        if y3 <> 5 then failwithf "no way Jose, y3 = %d, v = %d" y3 v
 
         5 
 
@@ -308,6 +314,35 @@ let f () =
     if m.Count <> 1 then failwith "unexpected"
 
 f()
+"""
+
+[<TestCase(true)>]
+[<TestCase(false, Ignore="needs dyntypes")>]
+let CustomAttributeSmokeTest(dyntypes: bool) =
+    SimpleTestCase false dyntypes "CustomAttributeSmokeTest" """
+
+open System
+[<Obsolete>]
+type UserType() = member x.P = 1
+
+let attrs = typeof<UserType>.GetCustomAttributes(typeof<ObsoleteAttribute>, true)
+if attrs.Length <> 1 then failwith "unexpected"
+
+"""
+
+[<TestCase(true)>]
+[<TestCase(false, Ignore="needs dyntypes")>]
+let CustomAttributeWithArgs(dyntypes: bool) =
+    SimpleTestCase false dyntypes "CustomAttributeWithArgs" """
+
+open System
+[<Obsolete("abc")>]
+type UserType() = member x.P = 1
+
+let attrs = typeof<UserType>.GetCustomAttributes(typeof<ObsoleteAttribute>, true)
+if attrs.Length <> 1 then failwith "unexpected"
+if (attrs.[0] :?> ObsoleteAttribute).Message <> "abc" then failwith "unexpected"
+
 """
 
 [<TestCase(true)>]

--- a/tests/PortaCodeTests.fs
+++ b/tests/PortaCodeTests.fs
@@ -263,7 +263,7 @@ module PlusOperator =
         """
 
 [<TestCase(true)>]
-//[<TestCase(false)>] // this only works with dyntypes
+[<TestCase(false, Ignore= "fails without dynamic emit types")>]
 let ImplementClassOverride(dyntypes: bool) =
     SimpleTestCase false dyntypes "ImplementClassOverride" """
 
@@ -279,7 +279,7 @@ f()
 
 
 //[<TestCase(true)>]
-////[<TestCase(false)>] // this only works with dyntypes
+//[<TestCase(false, Ignore= "fails without dynamic emit types")>]
 //let ImplementClassOverrideInGenericClass(dyntypes: bool) =
 //    SimpleTestCase false dyntypes "ImplementClassOverrideInGenericClass" """
 
@@ -627,7 +627,7 @@ if c.CodePage  <> System.Text.ASCIIEncoding().CodePage then failwith "nope"
         """
 
 [<TestCase(true)>]
-//[<TestCase(false)>]  this fails without dynamic types
+[<TestCase(false, Ignore= "fails without dynamic emit types")>]
 let SimpleInterfaceImpl(dyntypes) =
     SimpleTestCase false dyntypes "SimpleInterfaceImpl" """
 open System
@@ -642,7 +642,7 @@ if v <> 17 then failwithf "fail fail! expected 17, got %d"  v
 
 
 [<TestCase(true)>]
-//[<TestCase(false)>]  this fails without dynamic types
+[<TestCase(false, Ignore= "fails without dynamic emit types")>]
 let SimpleInterfaceImpl2(dyntypes) =
     SimpleTestCase false dyntypes "SimpleInterfaceImpl" """
 open System.Collections
@@ -718,6 +718,38 @@ type C(x: int, y: int) =
     member _.XY = x + y
 
 let c = C(3,4)
+if c.X <> 3 then failwith "fail fail! 1" 
+if c.Y <> 4 then failwith "fail fail! 2" 
+if c.XY <> 7 then failwith "fail fail! 3" 
+        """
+
+[<TestCase(true) >]
+//[<TestCase(false)>]
+let SimpleClassSelfConstructionNoArguments(dyntypes) =
+    SimpleTestCase false dyntypes "SimpleClass" """
+
+type C() =
+    member _.X = 1
+    member _.Y = 2
+    new (x: int, y: int, z: int) = C()
+
+let c = C(3,4,5) // interpretation calls self constructor
+if c.X <> 1 then failwith "fail fail! 1" 
+if c.Y <> 2 then failwith "fail fail! 2" 
+        """
+
+[<TestCase(true) >]
+//[<TestCase(false)>]
+let SimpleClassSelfConstructionWithArguments(dyntypes) =
+    SimpleTestCase false dyntypes "SimpleClass" """
+
+type C(x: int, y: int) =
+    member _.X = x
+    member _.Y = y
+    member _.XY = x + y
+    new (x: int, y: int, z: int) = C(x, y)
+
+let c = C(3,4,5) // interpretation calls self constructor
 if c.X <> 3 then failwith "fail fail! 1" 
 if c.Y <> 4 then failwith "fail fail! 2" 
 if c.XY <> 7 then failwith "fail fail! 3" 


### PR DESCRIPTION

* Complete operators such as sin, cos

*  Allow LiveCheck operators on types with Invoke checker implemented by the attribute, 

*  Allow LiveCheck operators on methods passing good locations through to the Invoke checker 

This allows customizable live checkers e.g. for

```
[<LiveCheck>]
type Math() =

    [<LiveCheck( [| "NX1"; "NX2" |], [| "NX2" |] ) >]
    member _.Add(x: Tensor, y: Tensor) = x + y + 1.0
```
