### PR TITLE
allow for generic trait calls

### DIFF
--- a/src/ProcessCommandLine.fs
+++ b/src/ProcessCommandLine.fs
@@ -261,7 +261,7 @@ let ProcessCommandLine (argv: string[]) =
                 sendToWebHook hook implFiles
                 Result.Ok()
             | None -> 
-            
+
             if not dump && webhook.IsNone then 
                 printfn "fslive: EVALUATING ALL INPUTS...." 
                 let evaluator = LiveCheckEvaluation(options.OtherOptions, dyntypes, writeinfo, keepRanges, livecheck, tolerateIncompleteExpressions)

--- a/src/ProcessCommandLine.fs
+++ b/src/ProcessCommandLine.fs
@@ -261,20 +261,21 @@ let ProcessCommandLine (argv: string[]) =
                 sendToWebHook hook implFiles
                 Result.Ok()
             | None -> 
-
+            
             if not dump && webhook.IsNone then 
                 printfn "fslive: EVALUATING ALL INPUTS...." 
                 let evaluator = LiveCheckEvaluation(options.OtherOptions, dyntypes, writeinfo, keepRanges, livecheck, tolerateIncompleteExpressions)
                 match evaluator.EvaluateDecls implFiles with
-                | Error _ when not watch -> exit 1
-                | _ -> ()
-
-            // The default is to dump
-            if dump && webhook.IsNone then 
+                | Error err when not watch -> Result.Error (None, None, None, None)
+                | _ -> Result.Ok()
+            elif dump && webhook.IsNone then 
+                // The default is to dump
                 let fileConvContents = jsonFiles (Array.ofList implFiles)
 
                 printfn "%A" fileConvContents
-            Result.Ok()
+                Result.Ok()
+            else
+                Result.Ok()
 
         with err when watch -> 
             printfn "fslive: exception: %A" (err.ToString())

--- a/tests/PortaCodeTests.fs
+++ b/tests/PortaCodeTests.fs
@@ -732,6 +732,22 @@ if a <> 3.0 then failwith "fail fail!"
 if b <> 4.0 then failwith "fail fail!" 
         """
 
+[<TestCase(true)>]
+//[<TestCase(false)>]
+let GenericMethodTraitCall(dyntypes) =
+    SimpleTestCase false dyntypes "GenericMethodTraitCall" """
+type C<'a,'b>(a : 'a, b : 'b) =
+    member _.A = a
+    member _.B = b
+    static member (-->)(x : C<'a,'b>,y : C<'b,'c>) : C<'a,'d> = C(x.A,y.B)
+
+let a = C(12,30.0)
+let b = C(20.0,30M)
+let c = (-->) a b
+if c.A <> 12 then failwith "fail fail! 1" 
+if c.B <> 30M then failwith "fail fail! 2" 
+        """
+
 [<TestCase(true, Ignore= "ignore because union types don't get dynamic emit types yet, codegen is too complicated and FCS doesn't tell us how") >]
 [<TestCase(false, Ignore= "fails without dynamic emit types")>]
 let UnionTypeWithOverride(dyntypes) =


### PR DESCRIPTION
Current version fails with missing method exception on op `-->` (DiffSharp). This is because `EvalTraitCallInvoke` uses `InvokeMember` which does not support generic methods. As an alternative type parameters are matched, generic methods are created and `Type.DefaultBinder.BindToMethod` is then called directly. 

This change alone fixes the diffsharp shape checking on `-->`. To add a test `exit` needed to be removed from `ProcessCommandLine` otherwise the failing test causes the test host process to exit. Furthermore since the test is not using a method in an external assembly, phase4 of `EmitInterpretExpression` needed to be updated to add generic parameters to the env prior to resolving parameter and return types. 
